### PR TITLE
Compile editable designs into constrained native InnerBlocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4298,6 +4298,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -7335,12 +7344,21 @@
       }
     },
     "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yjs": {

--- a/src/authoring/compile.ts
+++ b/src/authoring/compile.ts
@@ -1,0 +1,363 @@
+import type {
+  AuthoringDiagnostic,
+  AuthoringEditableField,
+  AuthoringNode,
+  AuthoringPlan,
+  AuthoringRole,
+  AuthoringTemplate,
+  CompiledAuthoringBlock,
+  InnerBlocksLock,
+} from '../types.js';
+
+const ROLE_BLOCKS: Record<Exclude<AuthoringRole, 'wrapper' | 'custom'>, string> = {
+  group: 'core/group',
+  columns: 'core/columns',
+  column: 'core/column',
+  cover: 'core/cover',
+  heading: 'core/heading',
+  paragraph: 'core/paragraph',
+  image: 'core/image',
+  list: 'core/list',
+  'list-item': 'core/list-item',
+  buttons: 'core/buttons',
+  button: 'core/button',
+  quote: 'core/quote',
+};
+
+const VALID_LOCKS = new Set<InnerBlocksLock>([false, 'insert', 'all', 'contentOnly']);
+
+/**
+ * Compile a reviewed authoring plan into a deliberately small registered-block source package.
+ *
+ * The generated wrapper has no content attributes. Its complete editable state is the native
+ * InnerBlocks template, which means WordPress owns the text, image, list, and button editor
+ * surfaces and serializes them normally.
+ */
+export function compileAuthoringPlan(plan: AuthoringPlan): CompiledAuthoringBlock {
+  const diagnostics: AuthoringDiagnostic[] = [];
+  const paths = new Set<string>();
+  const editableFields: AuthoringEditableField[] = [];
+
+  // The wrapper does not own an editor field, but its path is still part of the same stable plan
+  // namespace. Recording it catches accidental collisions with a child path.
+  notePath(plan.root, paths, diagnostics);
+
+  if (plan.root.role !== 'wrapper') {
+    diagnostics.push({
+      level: 'error',
+      code: 'invalid-root',
+      path: plan.root.path,
+      message: 'An authoring plan root must use the wrapper role; only its children become InnerBlocks.',
+    });
+  }
+
+  const template = (plan.root.children ?? []).map((node) => compileNode(node, paths, editableFields, diagnostics));
+  const allowedBlocks = unique(plan.allowedBlocks ?? template.map(([block]) => block));
+  const templateLock = normalizeLock(plan.templateLock, diagnostics);
+
+  if (templateLock === 'contentOnly') {
+    diagnostics.push({
+      level: 'warning',
+      code: 'gutenberg-76794',
+      path: plan.root.path,
+      message:
+        'WordPress 7.1 exposes Edit pattern controls for a top-level custom block with contentOnly InnerBlocks (Gutenberg #76794). The runtime fixture observes those controls; this is upstream UI, not invalid-block or recovery state.',
+    });
+  }
+
+  const files = sourceFiles({ plan, template, allowedBlocks, templateLock, editableFields, diagnostics });
+  return { files, template, allowedBlocks, templateLock, editableFields, diagnostics };
+}
+
+/** Alias kept readable for consumers that call the authoring API a compiler rather than a generator. */
+export const compileAuthoringBlock = compileAuthoringPlan;
+
+function compileNode(
+  node: AuthoringNode,
+  paths: Set<string>,
+  editableFields: AuthoringEditableField[],
+  diagnostics: AuthoringDiagnostic[],
+): [string, Record<string, unknown>, AuthoringTemplate?] {
+  notePath(node, paths, diagnostics);
+  const block = blockFor(node, diagnostics);
+  const attributes = initialAttributes(node, block);
+  const children = childrenFor(node, block).map((child) => compileNode(child, paths, editableFields, diagnostics));
+  const template: [string, Record<string, unknown>, AuthoringTemplate?] =
+    children.length > 0 ? [block, attributes, children] : [block, attributes];
+
+  editableFields.push(...editorSurfaces(node, block, attributes));
+  noteCustomInnerBlocks(node, diagnostics);
+  return template;
+}
+
+function notePath(node: AuthoringNode, paths: Set<string>, diagnostics: AuthoringDiagnostic[]): void {
+  if (typeof node.path !== 'string' || node.path.trim() === '') {
+    diagnostics.push({
+      level: 'error',
+      code: 'missing-path',
+      message: 'Every AuthoringNode needs a non-empty stable path.',
+    });
+    return;
+  }
+  if (paths.has(node.path)) {
+    diagnostics.push({
+      level: 'error',
+      code: 'duplicate-path',
+      path: node.path,
+      message: `AuthoringNode path ${JSON.stringify(node.path)} is used more than once.`,
+    });
+    return;
+  }
+  paths.add(node.path);
+}
+
+function blockFor(node: AuthoringNode, diagnostics: AuthoringDiagnostic[]): string {
+  if (node.role === 'custom') {
+    if (node.block) return node.block;
+    diagnostics.push({
+      level: 'error',
+      code: 'unsupported-role',
+      path: node.path,
+      message: 'A custom AuthoringNode requires its registered child block name.',
+    });
+    return 'core/group';
+  }
+  if (node.role === 'wrapper') {
+    diagnostics.push({
+      level: 'error',
+      code: 'unsupported-role',
+      path: node.path,
+      message: 'A wrapper is only valid as the plan root, never as a nested template node.',
+    });
+    return 'core/group';
+  }
+  const roleBlock = ROLE_BLOCKS[node.role];
+  if (!roleBlock) {
+    diagnostics.push({
+      level: 'error',
+      code: 'unsupported-role',
+      path: node.path,
+      message: `Authoring role ${JSON.stringify(node.role)} has no native Core block mapping.`,
+    });
+    return 'core/group';
+  }
+  if (node.block && node.block !== roleBlock) {
+    diagnostics.push({
+      level: 'warning',
+      code: 'unsupported-role',
+      path: node.path,
+      message: `Ignoring ${JSON.stringify(node.block)} for ${node.role}; this role must remain ${roleBlock}.`,
+    });
+  }
+  return roleBlock;
+}
+
+function initialAttributes(node: AuthoringNode, block: string): Record<string, unknown> {
+  const attributes = { ...(node.attributes ?? {}) };
+  switch (block) {
+    case 'core/heading':
+      attributes.content = node.content ?? asString(attributes.content, '');
+      attributes.level = node.level ?? asNumber(attributes.level, 2);
+      break;
+    case 'core/paragraph':
+    case 'core/list-item':
+      attributes.content = node.content ?? asString(attributes.content, '');
+      break;
+    case 'core/image':
+      attributes.url = node.url ?? asString(attributes.url, '');
+      attributes.alt = node.alt ?? asString(attributes.alt, '');
+      break;
+    case 'core/button':
+      attributes.text = node.content ?? asString(attributes.text, '');
+      attributes.url = node.url ?? asString(attributes.url, '');
+      break;
+    case 'core/quote':
+      // `value` is the pre-6.0 quote shape. WordPress 7.1 migrates it to inner blocks in the
+      // editor, which makes a generated leaf quote invalid after reopening. Quote text belongs
+      // to the explicit paragraph child emitted by childrenFor instead.
+      delete attributes.value;
+      break;
+  }
+  return attributes;
+}
+
+function childrenFor(node: AuthoringNode, block: string): AuthoringNode[] {
+  const children = node.children ?? [];
+  if (block !== 'core/quote') return children;
+
+  const attributes = node.attributes ?? {};
+  const hasLegacyValue = typeof attributes.value === 'string';
+  const hasQuoteContent = node.content !== undefined || hasLegacyValue;
+
+  // A leaf quote must still have a real Core paragraph editor surface. The derived path is stable
+  // in the compiled plan and manifest, rather than reporting the quote's obsolete `value` field.
+  if (children.length === 0 || hasQuoteContent) {
+    return [
+      {
+        path: `${node.path}.content`,
+        role: 'paragraph',
+        content: node.content ?? asString(attributes.value, ''),
+      },
+      ...children,
+    ];
+  }
+  return children;
+}
+
+function editorSurfaces(
+  node: AuthoringNode,
+  block: string,
+  attributes: Record<string, unknown>,
+): AuthoringEditableField[] {
+  const withPath = (attribute: string, surface: AuthoringEditableField['surface']): AuthoringEditableField => ({
+    path: node.path,
+    role: node.role,
+    block,
+    attribute,
+    surface,
+  });
+
+  switch (block) {
+    case 'core/heading':
+    case 'core/paragraph':
+    case 'core/list-item':
+      return 'content' in attributes ? [withPath('content', 'richText')] : [];
+    case 'core/image':
+      return [withPath('url', 'media'), withPath('alt', 'altText')];
+    case 'core/button':
+      return [withPath('text', 'richText'), withPath('url', 'link')];
+    default:
+      return [];
+  }
+}
+
+function noteCustomInnerBlocks(node: AuthoringNode, diagnostics: AuthoringDiagnostic[]): void {
+  const hasJustification = typeof node.justification === 'string' && node.justification.trim() !== '';
+  if (node.role === 'custom' && !hasJustification) {
+    diagnostics.push({
+      level: 'warning',
+      code: 'custom-child-justification-required',
+      path: node.path,
+      message:
+        'A custom child block was requested without a justification. Keep one region on the wrapper; record why this child is necessary before it owns specialised structure.',
+    });
+    return;
+  }
+  if (!node.requiresOwnInnerBlocks || (node.role === 'custom' && hasJustification)) return;
+  diagnostics.push({
+    level: 'warning',
+    code: 'multiple-innerblocks-regions',
+    path: node.path,
+    message:
+      'This design needs another InnerBlocks region. Keep one region on the wrapper; introduce a custom child only after recording why its own region is necessary.',
+  });
+}
+
+function normalizeLock(value: InnerBlocksLock | undefined, diagnostics: AuthoringDiagnostic[]): InnerBlocksLock {
+  if (value === undefined) return false;
+  if (VALID_LOCKS.has(value)) return value;
+  // This protects consumers receiving plan JSON at runtime; TypeScript callers cannot reach it.
+  diagnostics.push({
+    level: 'error',
+    code: 'invalid-root',
+    message: `Unsupported template lock ${JSON.stringify(value)}.`,
+  });
+  return false;
+}
+
+function sourceFiles({
+  plan,
+  template,
+  allowedBlocks,
+  templateLock,
+  editableFields,
+  diagnostics,
+}: {
+  plan: AuthoringPlan;
+  template: AuthoringTemplate;
+  allowedBlocks: string[];
+  templateLock: InnerBlocksLock;
+  editableFields: AuthoringEditableField[];
+  diagnostics: AuthoringDiagnostic[];
+}): Record<string, string> {
+  const metadata: Record<string, unknown> = {
+    $schema: 'https://schemas.wp.org/trunk/block.json',
+    apiVersion: 3,
+    name: plan.name,
+    title: plan.title,
+    category: plan.category ?? 'design',
+    icon: plan.icon ?? 'layout',
+    editorScript: 'file:./index.js',
+    style: 'file:./style-index.css',
+    allowedBlocks,
+    supports: { html: false },
+  };
+  if (plan.description) metadata.description = plan.description;
+  if (plan.textdomain) metadata.textdomain = plan.textdomain;
+
+  const manifest = {
+    version: 1,
+    rootPath: plan.root.path,
+    templateLock,
+    allowedBlocks,
+    editableFields,
+    diagnostics,
+  };
+
+  return {
+    'block.json': json(metadata),
+    'index.js': `import { registerBlockType } from '@wordpress/blocks';\nimport metadata from './block.json';\nimport Edit from './edit';\nimport save from './save';\nimport './style.scss';\n\nregisterBlockType( metadata.name, {\n  edit: Edit,\n  save,\n} );\n`,
+    'template.js': `export const TEMPLATE = ${json(template)};\nexport const ALLOWED_BLOCKS = ${json(allowedBlocks)};\nexport const TEMPLATE_LOCK = ${json(templateLock)};\n`,
+    'edit.js': `import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';\nimport { ALLOWED_BLOCKS, TEMPLATE, TEMPLATE_LOCK } from './template';\n\nexport default function Edit() {\n  const blockProps = useBlockProps();\n  const innerBlocksProps = useInnerBlocksProps( blockProps, {\n    allowedBlocks: ALLOWED_BLOCKS,\n    template: TEMPLATE,\n    templateLock: TEMPLATE_LOCK,\n  } );\n\n  return <div { ...innerBlocksProps } />;\n}\n`,
+    'save.js': `import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';\n\nexport default function save() {\n  const blockProps = useBlockProps.save();\n  const innerBlocksProps = useInnerBlocksProps.save( blockProps );\n\n  return <div { ...innerBlocksProps } />;\n}\n`,
+    'style.scss': `/* Generated wrapper styles belong here. Child content stays in native Core blocks. */\n`,
+    'authoring.manifest.json': json(manifest),
+    'README.md': readme(templateLock),
+  };
+}
+
+function readme(templateLock: InnerBlocksLock): string {
+  const lock = templateLock === false ? '`false`' : `\`${templateLock}\``;
+  const contentOnly =
+    templateLock === 'contentOnly'
+      ? '\n\n## WordPress 7.1 contentOnly limitation\n\nGutenberg #76794 exposes **Edit pattern** controls for a top-level custom block with `contentOnly` InnerBlocks. The WordPress 7.1 runtime fixture renders the Inspector and asserts that control is present. It is upstream UI, not invalid block markup or a recovery state. Changing the lock to `all` or `insert` changes the authoring model and is therefore not applied automatically.\n'
+      : '';
+  return `# Generated native InnerBlocks block\n\nThis package has one custom wrapper and one native InnerBlocks tree. Heading, paragraph, image, list, buttons, and button values are stored by their corresponding Core child blocks, not wrapper attributes.\n\nThe wrapper template lock is ${lock}: ${lockBehaviour(templateLock)} Its fixed direct-child allowlist is declared as top-level \`allowedBlocks\` in \`block.json\`; it is intentionally not a user-configurable support flag.\n${contentOnly}`;
+}
+
+function lockBehaviour(lock: InnerBlocksLock): string {
+  switch (lock) {
+    case false:
+      return 'it explicitly opts out of an inherited template lock, so insertion, removal, and moving remain available subject to the direct-child allowlist.';
+    case 'insert':
+      return 'it prevents insertion and removal while allowing existing children to move.';
+    case 'all':
+      return 'it prevents insertion, removal, and moving.';
+    case 'contentOnly':
+      return 'it prevents structural operations and exposes only native content surfaces; a child cannot override this lock.';
+  }
+}
+
+function json(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function unique(values: string[]): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (!seen.has(value)) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+  return result;
+}
+
+function asString(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}

--- a/src/headless/env.ts
+++ b/src/headless/env.ts
@@ -34,6 +34,8 @@ async function boot(): Promise<WpModules> {
       serialize: blocks.serialize,
       validateBlock: blocks.validateBlock,
       getBlockType: blocks.getBlockType,
+      registerBlockType: blocks.registerBlockType,
+      unregisterBlockType: blocks.unregisterBlockType,
     };
   } catch (error) {
     bootPromise = undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,27 @@ export { canonicalize } from './gate/canonicalize.js';
 export { validate } from './gate/validate.js';
 export { convert } from './convert/assemble.js';
 export { assemble, extractIntent, realize } from './intent/index.js';
+export { compileAuthoringBlock, compileAuthoringPlan } from './authoring/compile.js';
 export { collectSiteContext } from './context/run.js';
 export type { SiteContextOptions } from './context/run.js';
 export type {
   AssembleOptions,
+  AuthoringDiagnostic,
+  AuthoringEditableField,
+  AuthoringNode,
+  AuthoringPlan,
+  AuthoringRole,
+  AuthoringTemplate,
   BlockRunnerConfig,
   BlockRunnerReport,
   CanonicalizeOptions,
   CommandName,
   CommonOptions,
+  CompiledAuthoringBlock,
   ConvertOptions,
   IntentNode,
   IntentTree,
+  InnerBlocksLock,
   MediaConfig,
   MediaMapEntry,
   MediaResult,
@@ -27,6 +36,7 @@ export type {
   RuleContext,
   SourceLocation,
   StylingRung,
+  TemplateLock,
   TokenConfig,
   TokenMatchMode,
   TokenResolver,

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,6 +187,134 @@ export interface IntentTree {
   blocks: IntentNode[];
 }
 
+/**
+ * The lock applied to the one InnerBlocks area a generated block owns.
+ *
+ * `false` is intentional rather than an omitted value: it prevents an inherited template lock
+ * from leaking into an otherwise editable generated block.
+ */
+export type InnerBlocksLock = false | 'insert' | 'all' | 'contentOnly';
+/** Alias for callers that use the WordPress `templateLock` terminology. */
+export type TemplateLock = InnerBlocksLock;
+
+/**
+ * Semantic roles used by the registered-block authoring path.  Roles are deliberately about the
+ * editor surface, not the source HTML tag.  For example, a visual eyebrow is still a paragraph
+ * unless it has document-outline meaning and should be a heading.
+ */
+export type AuthoringRole =
+  | 'wrapper'
+  | 'group'
+  | 'columns'
+  | 'column'
+  | 'cover'
+  | 'heading'
+  | 'paragraph'
+  | 'image'
+  | 'list'
+  | 'list-item'
+  | 'buttons'
+  | 'button'
+  | 'quote'
+  | 'custom';
+
+/**
+ * A typed description of one node in a generated registered block.
+ *
+ * `path` is a producer-owned stable identifier, not an array index invented while emitting
+ * source. It lets previews, review UIs, and diagnostics point at exactly the same authoring
+ * decision after a template has been compiled. Ordinary values intentionally live on the native
+ * child (`content`, `url`, `alt`, and so on), never on the wrapper block.
+ */
+export interface AuthoringNode {
+  /** A stable, unique path within the plan, e.g. `hero.content.title`. */
+  path: string;
+  /** The editor-facing semantic role. */
+  role: AuthoringRole;
+  /**
+   * Explicitly select a block implementation. This is required for `custom`, optional for native
+   * roles (where the compiler supplies the matching core block).
+   */
+  block?: string;
+  /** Initial Gutenberg attributes for this child block. */
+  attributes?: Record<string, unknown>;
+  /** Initial rich-text value for heading, paragraph, list item, button, or a quote's generated paragraph child. */
+  content?: string;
+  /** Initial image or button URL. */
+  url?: string;
+  /** Initial image alternative text. */
+  alt?: string;
+  /** Initial heading level. */
+  level?: number;
+  /** Nested native block template. */
+  children?: AuthoringNode[];
+  /**
+   * A custom child that needs its own InnerBlocks region is allowed only with an explicit reason.
+   * This keeps the generated wrapper at exactly one InnerBlocks region by default.
+   */
+  justification?: string;
+  /** Whether this custom child requires a separately implemented InnerBlocks region. */
+  requiresOwnInnerBlocks?: boolean;
+}
+
+/** A generated package is one custom wrapper around this native child template. */
+export interface AuthoringPlan {
+  /** Fully-qualified registered block name, such as `acme/hero`. */
+  name: string;
+  title: string;
+  description?: string;
+  category?: string;
+  icon?: string;
+  textdomain?: string;
+  /** The semantic wrapper. Its children are the direct InnerBlocks children. */
+  root: AuthoringNode;
+  /** Default: `false`, so a post or pattern lock is not inherited accidentally. */
+  templateLock?: InnerBlocksLock;
+  /**
+   * Optional explicit direct-child allowlist. When absent it is inferred only from
+   * `root.children`; nested children do not leak into this list.
+   */
+  allowedBlocks?: string[];
+}
+
+/** A concrete native editor field rendered by a child block. */
+export interface AuthoringEditableField {
+  /** Stable plan path of the node that owns this surface. */
+  path: string;
+  role: AuthoringRole;
+  block: string;
+  attribute: string;
+  /** The native WordPress editor surface that owns the field. */
+  surface: 'richText' | 'media' | 'link' | 'altText';
+}
+
+export interface AuthoringDiagnostic {
+  level: 'warning' | 'error';
+  code:
+    | 'duplicate-path'
+    | 'missing-path'
+    | 'invalid-root'
+    | 'unsupported-role'
+    | 'custom-child-justification-required'
+    | 'multiple-innerblocks-regions'
+    | 'gutenberg-76794';
+  message: string;
+  path?: string;
+}
+
+/** Gutenberg's `[ name, attributes, children? ]` InnerBlocks template tuple. */
+export type AuthoringTemplate = Array<[string, Record<string, unknown>, AuthoringTemplate?]>;
+
+/** The deterministic source package emitted from an AuthoringPlan. */
+export interface CompiledAuthoringBlock {
+  files: Record<string, string>;
+  template: AuthoringTemplate;
+  allowedBlocks: string[];
+  templateLock: InnerBlocksLock;
+  editableFields: AuthoringEditableField[];
+  diagnostics: AuthoringDiagnostic[];
+}
+
 export type WpBlock = {
   name: string;
   attributes: Record<string, unknown>;
@@ -244,6 +372,8 @@ export interface WpModules {
   serialize: (blocks: WpBlock[] | WpBlock) => string;
   validateBlock: (block: WpBlock) => [boolean, unknown[]?];
   getBlockType: (name: string) => unknown;
+  registerBlockType: (nameOrMetadata: string | Record<string, unknown>, settings?: Record<string, unknown>) => unknown;
+  unregisterBlockType: (name: string) => unknown;
 }
 
 export class HeadlessBootError extends Error {

--- a/test/authoring.runtime.test.ts
+++ b/test/authoring.runtime.test.ts
@@ -1,0 +1,198 @@
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { compileAuthoringPlan } from '../src/index.js';
+import { getWp } from '../src/headless/wp.js';
+import type { AuthoringPlan, AuthoringTemplate, CompiledAuthoringBlock, InnerBlocksLock, WpBlock, WpModules } from '../src/types.js';
+
+const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'authoring');
+const require = createRequire(import.meta.url);
+
+type RuntimeBlock = WpBlock & { clientId: string; innerBlocks: RuntimeBlock[] };
+
+type BlockEditorRuntime = {
+  store: unknown;
+  BlockInspector: unknown;
+  useBlockProps: (() => Record<string, unknown>) & { save: () => Record<string, unknown> };
+  useInnerBlocksProps: {
+    (props: Record<string, unknown>, options: Record<string, unknown>): Record<string, unknown>;
+    save: (props: Record<string, unknown>) => Record<string, unknown>;
+  };
+};
+
+type DataRuntime = {
+  dispatch: (store: unknown) => Record<string, (...args: unknown[]) => unknown>;
+  select: (store: unknown) => Record<string, (...args: unknown[]) => unknown>;
+};
+
+type ElementRuntime = {
+  createElement: (type: unknown, props?: Record<string, unknown>) => unknown;
+  createRoot: (container: Element) => { render: (element: unknown) => void; unmount: () => void };
+  flushSync: (callback: () => void) => void;
+};
+
+const lockExpectations = {
+  insert: { insert: false, remove: false, move: true },
+  all: { insert: false, remove: false, move: false },
+  contentOnly: { insert: false, remove: false, move: false },
+} as const;
+
+function expectedStructuralOperations(templateLock: InnerBlocksLock): { insert: boolean; remove: boolean; move: boolean } {
+  return templateLock === false ? { insert: true, remove: true, move: true } : lockExpectations[templateLock];
+}
+
+function planFor(templateLock: InnerBlocksLock): AuthoringPlan {
+  return {
+    name: `block-runner/runtime-${templateLock === false ? 'unlocked' : templateLock.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`,
+    title: 'Runtime acceptance block',
+    templateLock,
+    root: {
+      path: 'runtime',
+      role: 'wrapper',
+      children: [
+        { path: 'runtime.title', role: 'heading', content: 'Original heading', level: 2 },
+        { path: 'runtime.copy', role: 'paragraph', content: 'Original paragraph' },
+        { path: 'runtime.image', role: 'image', url: 'https://example.test/original.jpg', alt: 'Original image' },
+        { path: 'runtime.quote', role: 'quote', content: 'Original native quote' },
+      ],
+    },
+  };
+}
+
+function runtimeBlock(block: WpBlock): RuntimeBlock {
+  return block as RuntimeBlock;
+}
+
+function blocksFromTemplate(wp: WpModules, template: AuthoringTemplate): RuntimeBlock[] {
+  return template.map(([name, attributes, children]) =>
+    runtimeBlock(wp.createBlock(name, attributes, children ? blocksFromTemplate(wp, children) : [])),
+  );
+}
+
+function registerCompiledBlock(
+  wp: WpModules,
+  compiled: CompiledAuthoringBlock,
+  editor: BlockEditorRuntime,
+  element: ElementRuntime,
+): string {
+  const metadata = JSON.parse(compiled.files['block.json']!) as Record<string, unknown>;
+  const name = metadata.name as string;
+
+  const edit = () => {
+    const blockProps = editor.useBlockProps();
+    const innerBlocksProps = editor.useInnerBlocksProps(blockProps, {
+      allowedBlocks: compiled.allowedBlocks,
+      template: compiled.template,
+      templateLock: compiled.templateLock,
+    });
+    return element.createElement('div', innerBlocksProps);
+  };
+  const save = () => {
+    const blockProps = editor.useBlockProps.save();
+    const innerBlocksProps = editor.useInnerBlocksProps.save(blockProps);
+    return element.createElement('div', innerBlocksProps);
+  };
+
+  expect(wp.registerBlockType(metadata, { edit, save })).toBeTruthy();
+  return name;
+}
+
+function mountCompiledBlock(
+  wp: WpModules,
+  compiled: CompiledAuthoringBlock,
+  actions: Record<string, (...args: unknown[]) => unknown>,
+  selectors: Record<string, (...args: unknown[]) => unknown>,
+): { rootId: string; childIds: string[] } {
+  const metadata = JSON.parse(compiled.files['block.json']!) as { name: string };
+  const block = runtimeBlock(wp.createBlock(metadata.name, {}, blocksFromTemplate(wp, compiled.template)));
+  actions.resetBlocks([block]);
+  actions.updateBlockListSettings(block.clientId, {
+    allowedBlocks: compiled.allowedBlocks,
+    template: compiled.template,
+    templateLock: compiled.templateLock,
+  });
+
+  return {
+    rootId: block.clientId,
+    childIds: selectors.getBlockOrder(block.clientId) as string[],
+  };
+}
+
+function expectValidTree(wp: WpModules, block: RuntimeBlock): void {
+  expect(wp.validateBlock(block)[0]).toBe(true);
+  for (const child of block.innerBlocks) expectValidTree(wp, child);
+}
+
+describe('generated registered blocks in WordPress 7.1', () => {
+  it.each([false, 'insert', 'all', 'contentOnly'] as const satisfies readonly InnerBlocksLock[])(
+    'registers, persists native edits, and enforces %s structural operations',
+    async (templateLock) => {
+      const wp = await getWp();
+      const editor = require('@wordpress/block-editor') as BlockEditorRuntime;
+      const data = require('@wordpress/data') as DataRuntime;
+      const element = require('@wordpress/element') as ElementRuntime;
+      const actions = data.dispatch(editor.store);
+      const selectors = data.select(editor.store);
+      const compiled = compileAuthoringPlan(planFor(templateLock));
+      const name = registerCompiledBlock(wp, compiled, editor, element);
+      const expected = expectedStructuralOperations(templateLock);
+
+      try {
+        const persisted = mountCompiledBlock(wp, compiled, actions, selectors);
+        actions.updateBlockAttributes(persisted.childIds[0], { content: 'Edited after reopening.' });
+        const saved = wp.serialize([selectors.getBlock(persisted.rootId) as RuntimeBlock]);
+        const reopened = wp.parse(saved).map(runtimeBlock);
+
+        expect(saved).toContain('Edited after reopening.');
+        expect(reopened).toHaveLength(1);
+        expect(wp.serialize(reopened)).toContain('Edited after reopening.');
+        expect(wp.serialize(reopened)).toBe(saved);
+        expectValidTree(wp, reopened[0]!);
+
+        const inserted = mountCompiledBlock(wp, compiled, actions, selectors);
+        const beforeInsert = selectors.getBlockOrder(inserted.rootId) as string[];
+        actions.insertBlock(wp.createBlock('core/image', { url: 'https://example.test/added.jpg', alt: 'Added image' }), undefined, inserted.rootId, false);
+        expect(selectors.getBlockOrder(inserted.rootId)).toHaveLength(beforeInsert.length + Number(expected.insert));
+
+        const removed = mountCompiledBlock(wp, compiled, actions, selectors);
+        actions.removeBlock(removed.childIds[0], false);
+        expect((selectors.getBlockOrder(removed.rootId) as string[]).includes(removed.childIds[0]!)).toBe(!expected.remove);
+
+        const moved = mountCompiledBlock(wp, compiled, actions, selectors);
+        actions.moveBlockToPosition(moved.childIds[0], moved.rootId, moved.rootId, 1);
+        expect((selectors.getBlockOrder(moved.rootId) as string[])[1]).toBe(expected.move ? moved.childIds[0] : moved.childIds[1]);
+      } finally {
+        wp.unregisterBlockType(name);
+      }
+    },
+  );
+
+  it('observes the WordPress 7.1 Edit pattern Inspector control in the contentOnly fixture', async () => {
+    const wp = await getWp();
+    const editor = require('@wordpress/block-editor') as BlockEditorRuntime;
+    const data = require('@wordpress/data') as DataRuntime;
+    const element = require('@wordpress/element') as ElementRuntime;
+    const actions = data.dispatch(editor.store);
+    const selectors = data.select(editor.store);
+    const fixture = JSON.parse(await readFile(path.join(FIXTURES, 'content-only.plan.json'), 'utf8')) as AuthoringPlan;
+    const compiled = compileAuthoringPlan(fixture);
+    const name = registerCompiledBlock(wp, compiled, editor, element);
+    const target = document.createElement('div');
+    const inspector = element.createRoot(target);
+
+    try {
+      const mounted = mountCompiledBlock(wp, compiled, actions, selectors);
+      actions.selectBlock(mounted.rootId);
+
+      document.body.append(target);
+      element.flushSync(() => inspector.render(element.createElement(editor.BlockInspector)));
+      expect(target.textContent).toContain('Edit pattern');
+    } finally {
+      inspector.unmount();
+      target.remove();
+      wp.unregisterBlockType(name);
+    }
+  });
+});

--- a/test/authoring.test.ts
+++ b/test/authoring.test.ts
@@ -1,0 +1,167 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { compileAuthoringPlan } from '../src/index.js';
+import type { AuthoringPlan, InnerBlocksLock } from '../src/types.js';
+
+const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'authoring');
+
+function representativePlan(templateLock: InnerBlocksLock = false): AuthoringPlan {
+  return {
+    name: 'acme/editorial-hero',
+    title: 'Editorial hero',
+    description: 'A wrapper with only native editable content.',
+    templateLock,
+    root: {
+      path: 'hero',
+      role: 'wrapper',
+      children: [
+        { path: 'hero.title', role: 'heading', content: 'A native heading', level: 1 },
+        { path: 'hero.summary', role: 'paragraph', content: 'A native paragraph.' },
+        {
+          path: 'hero.image',
+          role: 'image',
+          url: 'https://example.test/hero.jpg',
+          alt: 'Editorial hero',
+        },
+        {
+          path: 'hero.points',
+          role: 'list',
+          attributes: { ordered: true },
+          children: [
+            { path: 'hero.points.first', role: 'list-item', content: 'First point' },
+            { path: 'hero.points.second', role: 'list-item', content: 'Second point' },
+          ],
+        },
+        {
+          path: 'hero.actions',
+          role: 'buttons',
+          children: [
+            { path: 'hero.actions.primary', role: 'button', content: 'Start', url: '/start' },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+describe('registered block authoring compiler', () => {
+  it('keeps representative editable content in one native InnerBlocks template', () => {
+    const compiled = compileAuthoringPlan(representativePlan('all'));
+    const metadata = JSON.parse(compiled.files['block.json']!);
+
+    expect(compiled.template).toEqual([
+      ['core/heading', { content: 'A native heading', level: 1 }],
+      ['core/paragraph', { content: 'A native paragraph.' }],
+      ['core/image', { url: 'https://example.test/hero.jpg', alt: 'Editorial hero' }],
+      [
+        'core/list',
+        { ordered: true },
+        [
+          ['core/list-item', { content: 'First point' }],
+          ['core/list-item', { content: 'Second point' }],
+        ],
+      ],
+      ['core/buttons', {}, [['core/button', { text: 'Start', url: '/start' }]]],
+    ]);
+
+    expect(metadata).toMatchObject({
+      apiVersion: 3,
+      name: 'acme/editorial-hero',
+      allowedBlocks: ['core/heading', 'core/paragraph', 'core/image', 'core/list', 'core/buttons'],
+      supports: { html: false },
+    });
+    expect(metadata.attributes).toBeUndefined();
+    expect(metadata.supports.allowedBlocks).toBeUndefined();
+    expect(compiled.files['block.json']).not.toContain('A native heading');
+
+    expect(compiled.files['edit.js']).toContain('const blockProps = useBlockProps();');
+    expect(compiled.files['edit.js']).toContain('useInnerBlocksProps( blockProps, {');
+    expect(compiled.files['edit.js']).toContain('allowedBlocks: ALLOWED_BLOCKS');
+    expect(compiled.files['edit.js']).toContain('templateLock: TEMPLATE_LOCK');
+    expect(compiled.files['edit.js']).toContain('return <div { ...innerBlocksProps } />;');
+    expect(compiled.files['save.js']).toContain('const blockProps = useBlockProps.save();');
+    expect(compiled.files['save.js']).toContain('useInnerBlocksProps.save( blockProps )');
+    expect(compiled.files['save.js']).toContain('return <div { ...innerBlocksProps } />;');
+
+    expect(compiled.editableFields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: 'hero.title', block: 'core/heading', attribute: 'content', surface: 'richText' }),
+        expect.objectContaining({ path: 'hero.summary', block: 'core/paragraph', attribute: 'content', surface: 'richText' }),
+        expect.objectContaining({ path: 'hero.image', block: 'core/image', attribute: 'url', surface: 'media' }),
+        expect.objectContaining({ path: 'hero.points.first', block: 'core/list-item', attribute: 'content', surface: 'richText' }),
+        expect.objectContaining({ path: 'hero.actions.primary', block: 'core/button', attribute: 'text', surface: 'richText' }),
+        expect.objectContaining({ path: 'hero.actions.primary', block: 'core/button', attribute: 'url', surface: 'link' }),
+      ]),
+    );
+  });
+
+  it('gives a quote its own stable paragraph child instead of the retired value surface', () => {
+    const plan = representativePlan();
+    plan.root.children!.push({
+      path: 'hero.quote',
+      role: 'quote',
+      content: 'Native quote text.',
+    });
+
+    const compiled = compileAuthoringPlan(plan);
+
+    expect(compiled.template.at(-1)).toEqual([
+      'core/quote',
+      {},
+      [['core/paragraph', { content: 'Native quote text.' }]],
+    ]);
+    expect(compiled.editableFields).toContainEqual({
+      path: 'hero.quote.content',
+      role: 'paragraph',
+      block: 'core/paragraph',
+      attribute: 'content',
+      surface: 'richText',
+    });
+    expect(compiled.editableFields).not.toContainEqual(
+      expect.objectContaining({ path: 'hero.quote', block: 'core/quote' }),
+    );
+  });
+
+  for (const templateLock of [false, 'insert', 'all', 'contentOnly'] as const satisfies readonly InnerBlocksLock[]) {
+    it(`emits the confirmed ${String(templateLock)} locking mode without changing the child template`, () => {
+      const compiled = compileAuthoringPlan(representativePlan(templateLock));
+      expect(compiled.templateLock).toBe(templateLock);
+      expect(compiled.files['template.js']).toContain(`export const TEMPLATE_LOCK = ${JSON.stringify(templateLock)};`);
+      expect(compiled.files['edit.js']).toContain('templateLock: TEMPLATE_LOCK');
+    });
+  }
+
+  it('documents the WordPress 7.1 contentOnly limitation without treating it as invalid markup', async () => {
+    const fixture = JSON.parse(await readFile(path.join(FIXTURES, 'content-only.plan.json'), 'utf8')) as AuthoringPlan;
+    const compiled = compileAuthoringPlan(fixture);
+
+    expect(compiled.diagnostics).toContainEqual(
+      expect.objectContaining({ level: 'warning', code: 'gutenberg-76794' }),
+    );
+    expect(compiled.files['README.md']).toContain('Gutenberg #76794');
+    expect(compiled.files['README.md']).toContain('runtime fixture renders the Inspector');
+    expect(compiled.files['README.md']).toContain('not invalid block markup or a recovery state');
+    expect(JSON.parse(compiled.files['block.json']!).attributes).toBeUndefined();
+  });
+
+  it('warns instead of silently creating a second wrapper InnerBlocks region', () => {
+    const plan = representativePlan();
+    plan.root.children!.push({
+      path: 'hero.carousel',
+      role: 'custom',
+      block: 'acme/carousel-slide',
+      requiresOwnInnerBlocks: true,
+    });
+
+    const compiled = compileAuthoringPlan(plan);
+    expect(compiled.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: 'warning',
+        code: 'custom-child-justification-required',
+        path: 'hero.carousel',
+      }),
+    );
+  });
+});

--- a/test/fixtures/authoring/content-only.plan.json
+++ b/test/fixtures/authoring/content-only.plan.json
@@ -1,0 +1,22 @@
+{
+  "name": "acme/content-only-card",
+  "title": "Content-only card",
+  "templateLock": "contentOnly",
+  "root": {
+    "path": "card",
+    "role": "wrapper",
+    "children": [
+      {
+        "path": "card.title",
+        "role": "heading",
+        "content": "A real Core heading",
+        "level": 2
+      },
+      {
+        "path": "card.copy",
+        "role": "paragraph",
+        "content": "Only native child content is editable."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Problem

A reusable block is still a poor WordPress citizen if headings, images, links and buttons become bespoke fields or frozen HTML. The design needs to stay intact without replacing the editor behaviour WordPress already provides. Closes #4.

## Solution

Generate a thin custom wrapper around one native `InnerBlocks` tree. Ordinary content remains in Core Heading, Paragraph, Image, List, Buttons and Button blocks. The plan controls the template, direct-child allowlist, editability and locking, while fixed structure stays out of the outer block's content attributes.

## Testing and verification

The native-child, locking and content-only contracts are covered by the repository tests and the real WordPress lifecycle used by the current integration. The public verification record is the [green CI run](https://github.com/humanmade/block-runner/actions/runs/33879578421) on Node 20, 22 and 24 with WordPress 7.1.

## Risk and rollout

The static path does not generate arbitrary controls or dynamic rendering. Designs that cannot fit one native content region fail with a source-located reason rather than silently becoming custom HTML.
