### PR TITLE
Add the typed authoring plan and hash-bound terminal confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Gutenberg before it reaches the editor.
 | --- | --- |
 | `convert` | Authored HTML to native blocks. The only path that carries CSS. |
 | `assemble` | An intent tree — JSON describing which blocks and how they nest — to native blocks, built with `createBlock` so the result cannot be invalid. |
+| `author preview <plan\|->` | Validate and render a versioned registered-block AuthoringPlan without writing files. |
+| `author write <plan\|-> --confirm <hash> --output-dir <dir>` | Write only the reviewed plan bound to its SHA-256 confirmation and destination. |
 | `validate` | Check block markup against headless Gutenberg. |
 | `fix` | Canonicalize near-miss block markup. |
 | `context` | Read a WordPress site into a `site.context.json` manifest (read-only). |
@@ -157,6 +159,43 @@ block-runner assemble intent.json                 # structure in, blocks out
 block-runner validate "content/**/*.html" --json
 block-runner fix post-content.html --out post-content.fixed.html
 ```
+
+### Registered-block authoring
+
+For a reusable registered block, first make a versioned **AuthoringPlan** rather than jumping
+from a description or design directly to source. The plan records the block target and native
+structure, editable and locked fields, style outcomes, pattern overrides, assets, planned files,
+and warnings. Review it before any write:
+
+```sh
+block-runner author preview authoring-plan.json --output-dir generated/feature-grid
+```
+
+The plain preview is deterministic for a plan, generator version, destination snapshot, and
+terminal width. It shows the plan SHA-256 and a separate confirmation SHA-256 bound to the
+planned destination and its fingerprint, labels fixed/editable/override fields without relying
+on colour, and ends with `No files written.` Preview is
+read-only; it has no prompt. `NO_COLOR` is honoured, and `--json` never contains ANSI escape
+sequences.
+
+An installed Block Runner skill presents that preview to the user and asks for explicit
+approval. The CLI itself is always non-interactive. After the user approves the displayed
+confirmation hash, write the exact same plan to the previewed output directory. `--output-dir` is
+the exact package destination (not a parent root):
+
+```sh
+block-runner author write authoring-plan.json \
+  --confirm '<full-sha-256-from-preview>' \
+  --output-dir '<the-previewed-directory>'
+```
+
+Missing, stale, or incorrect confirmation values write nothing. If a plan replaces existing
+files, get a distinct, explicit replacement decision; a path collision, traversal or absolute
+path, changed destination, or any destination-prefix symlink fails before any write. The command
+rechecks these conditions immediately before exclusive, atomic writes. Use `-` for plan input
+only—never as a source of confirmation. Source generation is separate: this preview release writes only
+`files[].content` already contained in the confirmed plan, so a plan with descriptions alone is
+a successful no-op.
 
 Read from stdin with `-`:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -763,6 +763,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -779,6 +780,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -795,6 +797,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -811,6 +814,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -827,6 +831,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -843,6 +848,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -859,6 +865,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -875,6 +882,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -891,6 +899,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -907,6 +916,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -923,6 +933,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -939,6 +950,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -955,6 +967,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -971,6 +984,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -987,6 +1001,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1003,6 +1018,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1019,6 +1035,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,6 +1052,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1051,6 +1069,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1067,6 +1086,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1083,6 +1103,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1099,6 +1120,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1115,6 +1137,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1131,6 +1154,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1147,6 +1171,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1163,6 +1188,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6840,6 +6866,24 @@
         "node": ">= 12"
       }
     },
+    "node_modules/tsup/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.23.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
@@ -7211,6 +7255,24 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/skills/block-runner/SKILL.md
+++ b/skills/block-runner/SKILL.md
@@ -17,8 +17,16 @@ package.
 
 ## The short version
 
-Three paths. Pick by what you have:
+Four paths. Pick by what you have:
 
+- **You are authoring a reusable, registered block** → first make a versioned `AuthoringPlan`
+  that captures the block identity, native structure, editable and locked parts, style outcomes,
+  pattern overrides, assets, and planned files. Run `author preview` and show its plain-text
+  result to the user. The preview's confirmation SHA-256 is bound to the exact plan and destination
+  snapshot that may be written. The installed
+  skill—not the CLI—asks for a clear conversational confirmation after the user has seen that
+  preview. Only then run `author write` with that full confirmation hash and an explicit output directory.
+  Do not generate source during the conversation or treat a prose description as a plan.
 - **You are inventing the structure** → do not write HTML. Emit an intent tree (JSON
   describing which blocks and how they nest) and pipe it to
   `npx -y block-runner@latest assemble - --json`. Deterministic code builds the markup, so it
@@ -44,6 +52,13 @@ Three paths. Pick by what you have:
 - **If the CSS matters, use `convert`, not `assemble`.** An intent tree carries structure and
   content, not styling. Ask the user rather than silently flattening their design.
 - **Passwords go in `--wp-app-password-env <NAME>`, never in argv.**
+- **Registered-block authoring is preview first.** `author preview` writes no files; never
+  invoke `author write` until the user has seen the matching preview and affirmatively approved
+  it. Pass the confirmation hash displayed there with `--confirm`; the core deliberately never prompts.
+- **Replacement needs its own yes.** If the preview says any planned file will replace an
+  existing file, name those files and obtain an explicit replacement decision in addition to
+  approval of the plan. A collision or unsafe destination is a stop, not something to work
+  around.
 - **It is an assist, not a gate.** If the tool is unavailable, fall back to your own checks and
   say so — never block the user on it.
 

--- a/skills/block-runner/references/GUIDE.md
+++ b/skills/block-runner/references/GUIDE.md
@@ -16,6 +16,7 @@ access to fetch the package. **You** are the model in this pipeline.
 
 | You have | Use | Why |
 |---|---|---|
+| A reusable registered block to author — before source exists | **`author preview`** → user confirmation → **`author write`** | A versioned AuthoringPlan makes the consequential implementation choices reviewable and hash-binds the write. |
 | A design in your head, or HTML you are about to write | **`assemble`** | You describe the structure; Block Runner builds valid blocks from it. Best structural results. |
 | Authored source HTML — a design tool export, source file, or paste | **`convert`** | Rule-based translation of existing markup, and the only path that carries CSS. Do not use frontend-scraped render output. |
 | Block markup you already produced, before saving it to WordPress | **`validate`** → **`fix`** → **`validate`** | Proves the editor will accept it. |
@@ -32,7 +33,98 @@ unsure whether the styling matters, ask the user rather than silently flattening
 
 ---
 
-## 2. `assemble` — describe the structure, get valid blocks
+## 2. Registered-block authoring — preview the plan before a write
+
+Use this path when the requested result is a reusable, registered WordPress block source
+package. It is not an HTML conversion path and it does not let a prose description stand in for
+implementation decisions. First make an **`AuthoringPlan`**: a versioned JSON contract that
+names the target block and records its native child structure, editable fields, locking, style
+outcomes, pattern overrides, assets, planned files, and warnings. A plan is the thing being
+reviewed and, eventually, written.
+
+AuthoringPlan v1 has these top-level fields. Omitted optional sections canonicalize to their
+documented empty/default form; object keys are recursively sorted for canonical JSON, while
+array order remains material.
+
+| Field | Contract |
+|---|---|
+| `version` | Required literal `1`. |
+| `generatorVersion` | Required generator identity/version; it participates in the confirmation hash. |
+| `target` | Required `{ "name": "namespace/slug", "title": "…" }`; `directory`, when present, is a safe relative package path. |
+| `structure` | Native block nodes: `block`, optional stable `id`, `label`, `attributes`, per-node `lock`, and `children`. Never HTML. |
+| `fields` | Editor values with `id`, `label`, and explicit `mode`: `fixed`, `editable`, or `override`; may identify a structure `node`, `attribute`, type, default, and description. |
+| `locking` | Whole-block lock mode (`all`, `contentOnly`, or `none`) and optional move/remove/insert permissions. |
+| `styles` | Strategy (`native`, `scoped-css`, or `mixed`) plus a disposition for each source property: `native`, `token`, `scoped-css`, or `dropped`. |
+| `pattern` | Readiness flag and overrides that name their field. |
+| `assets` | Identified sources with optional safe relative destinations, availability status, and required flag. |
+| `files` | Planned safe relative paths, optional materialized `content`, optional kind, and `operation: create|replace` (omitted means `create`). `plannedFiles` is only accepted as an input alias and canonicalizes to `files`. |
+| `warnings` | Any unresolved or deliberate caveats. |
+
+The plan must make every material choice explicit. In particular, label fields as **fixed**,
+**editable**, or **override**; say which styles map to native or theme support and which need a
+different outcome; and identify every replacement as `replace` (new files default to `create`).
+Do not hide those choices in generated code, HTML, a chat summary, or an implied default.
+
+### Preview, then talk to the user
+
+```bash
+npx -y block-runner@latest author preview authoring-plan.json --output-dir generated/feature-grid
+```
+
+`author preview` is read-only. It validates and canonicalizes the plan, computes a SHA-256
+confirmation value bound to both the plan and the selected destination fingerprint, and prints a
+deterministic plain-text review. It includes the target, structure, editable fields, style
+outcomes, assets, pattern readiness, planned files, warnings, destination fingerprint, and the
+unambiguous line **`No files written.`** It labels fixed, editable, and override fields in text,
+so colour is never needed to understand it. Terminal width affects wrapping only; `NO_COLOR` is
+honoured and the preview never inserts ANSI escape sequences into JSON.
+
+Read this preview before asking for consent. Summarize the decisions in ordinary language and
+show the complete 64-character, lower-case hexadecimal confirmation SHA-256. The installed skill
+owns the conversation: ask a clear yes/no
+question such as “Approve writing exactly this plan, identified by `<hash>`, to `<directory>`?”
+Do not ask the CLI to prompt, and do not consider an earlier or general “go ahead” to approve a
+changed plan.
+
+If any planned file is a replacement, ask separately and name the affected files. Replacing an
+existing file is a distinct decision from creating the plan; no affirmative replacement answer
+means no `author write`.
+
+### Write only the previewed plan
+
+After the user has affirmatively approved the displayed confirmation hash (and any replacements), run:
+
+```bash
+npx -y block-runner@latest author write authoring-plan.json \
+  --confirm '<full-sha-256-from-preview>' \
+  --output-dir '<the-previewed-directory>'
+```
+
+Pass the full confirmation hash exactly as the preview displayed it; `--output-dir` names the
+exact package destination, rather than a parent directory. The command is intentionally
+non-interactive: it never opens a prompt and never consumes stdin as confirmation. This also
+applies with `--json` and when stdout is redirected. A missing, stale, or incorrect hash must
+be treated as a no-write result, not as a reason to retry with a looser invocation.
+
+`-` may supply the plan on stdin (`author preview -` or `author write -`); it is only plan input,
+never confirmation input. For a write, provide the same canonical plan that was previewed, the
+same destination, and the confirmation hash from that preview. If any changes, preview it again
+and obtain fresh consent.
+
+Do not work around a rejected write. Unsafe relative paths, absolute paths, `..` traversal,
+destination changes, collisions, or a symlink in the selected output directory's prefix
+are failures before any write. The command rechecks the destination fingerprint, paths,
+symlinks, and collisions immediately before it uses exclusive, atomic file writes. Surface the
+failure, revise the plan or destination safely, then start again at preview.
+
+Generation of source is deliberately separate from this review loop. `author write` can
+materialize only `files[].content` already present in the exact reviewed plan; a plan that only
+describes future files is a valid no-op. Do not pretend that `author preview` generated files,
+parse its display back into JSON, or use `author write` to fill decisions the plan omitted.
+
+---
+
+## 3. `assemble` — describe the structure, get valid blocks
 
 You emit a JSON tree describing *what blocks and where*. Deterministic code turns that into
 markup. You never write `<!-- wp:... -->` markup yourself — that is the whole point. Writing
@@ -173,7 +265,7 @@ not registered produces a warning naming that node.
 
 ---
 
-## 3. `convert` — someone else's HTML
+## 4. `convert` — someone else's HTML
 
 ```bash
 printf '%s' "$PASTED_HTML" | npx -y block-runner@latest convert - --json
@@ -200,7 +292,7 @@ design yourself and describing it as an intent tree instead.
 
 ---
 
-## 4. The pre-flight loop — before anything is saved
+## 5. The pre-flight loop — before anything is saved
 
 Run this on block markup before you write it to WordPress:
 
@@ -243,7 +335,7 @@ Read `.ok` and `.summary.invalid` for the verdict, `.items[].source.htmlLine` fo
 
 ---
 
-## 5. Where the blocks go
+## 6. Where the blocks go
 
 Producing valid markup is not the end of the job. Every run ends in one of three places, and
 you pick based on what is available — never leave the markup sitting in a temp file or scroll
@@ -273,7 +365,7 @@ Custom HTML. A silent success is indistinguishable from a silent failure.
 
 ---
 
-## 6. Matching the user's site
+## 7. Matching the user's site
 
 Optional, and worth it when you know the target site.
 
@@ -288,7 +380,7 @@ Optional, and worth it when you know the target site.
 
 ---
 
-## 7. Failure posture
+## 8. Failure posture
 
 Block Runner is an assist, not a gate that can strand the user.
 
@@ -305,7 +397,7 @@ harmless. Read results from stdout or `--json`. Users who run this often can
 
 ---
 
-## 8. Installing this as a skill
+## 9. Installing this as a skill
 
 If your harness supports skills, install the canonical skill into the current project:
 

--- a/src/authoring/destination.ts
+++ b/src/authoring/destination.ts
@@ -1,0 +1,441 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { link, lstat, mkdir, open, readFile, readlink, rename, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import { hashAuthoringPlan, type AuthoringPlan } from './schema.js';
+
+/** A read-only representation of the filesystem state relevant to a plan. */
+export interface DestinationInspection {
+  directory: string;
+  fingerprint: string;
+  entries: ReadonlyArray<DestinationEntry>;
+}
+
+/** The destination facts a preview binds into its write confirmation. */
+export interface AuthoringDestinationApproval {
+  directory: string;
+  fingerprint: string;
+}
+
+export interface DestinationEntry {
+  path: string;
+  kind: 'directory' | 'file' | 'missing';
+  identity?: FileIdentity;
+}
+
+interface FileIdentity {
+  dev: string;
+  ino: string;
+  mode: number;
+  size: string;
+  mtimeNs: string;
+  ctimeNs: string;
+  sha256?: string;
+}
+
+interface MaterializedFile {
+  path: string;
+  content: string;
+  replace: boolean;
+}
+
+interface PlannedOutput {
+  path: string;
+  content?: unknown;
+  replace: boolean;
+}
+
+/**
+ * Snapshot a destination without making it exist. Apart from a small fixed set of OS-owned root
+ * aliases, every lexical component from the filesystem root to the requested path is lstat'ed,
+ * so no user-controlled link is ever resolved before it can be rejected.
+ */
+export async function inspectAuthoringDestination(
+  outputDirectory: string,
+  plan: AuthoringPlan,
+): Promise<DestinationInspection> {
+  const directory = await canonicalizeTrustedSystemAlias(outputDirectory);
+  const files = plannedFiles(plan);
+  const entries = new Map<string, DestinationEntry>();
+
+  await inspectDirectoryPath(directory, entries);
+  for (const file of files) {
+    await inspectPlannedPath(directory, file.path, entries);
+  }
+
+  const ordered = [...entries.values()].sort((left, right) => left.path.localeCompare(right.path));
+  return {
+    directory,
+    fingerprint: fingerprint({ directory, entries: ordered }),
+    entries: ordered,
+  };
+}
+
+/**
+ * Produce the value accepted by `author write --confirm`. It binds the canonical plan to the
+ * exact lexical destination and filesystem snapshot shown by `author preview`.
+ */
+export function hashAuthoringConfirmation(
+  plan: AuthoringPlan,
+  destination: AuthoringDestinationApproval,
+): string {
+  return hashBuffer(Buffer.from(stableJson({
+    planHash: hashAuthoringPlan(plan),
+    destination: {
+      directory: path.resolve(destination.directory),
+      fingerprint: destination.fingerprint,
+    },
+  }), 'utf8'));
+}
+
+/**
+ * Materialize only file content already present in a reviewed plan.  This is deliberately not a
+ * source generator: plans which only describe future files are a successful no-op.  New files
+ * are published through an exclusive hard-link, while replacements require the plan's separate
+ * hash-bound decision.
+ */
+export async function writeAuthoringPlan(
+  outputDirectory: string,
+  plan: AuthoringPlan,
+  approval?: AuthoringDestinationApproval,
+): Promise<{ directory: string; fingerprint: string; written: string[] }> {
+  const allFiles = plannedFiles(plan);
+  const files = allFiles.filter((file): file is MaterializedFile => typeof file.content === 'string');
+  const before = await inspectAuthoringDestination(outputDirectory, plan);
+  if (approval && (before.directory !== path.resolve(approval.directory) || before.fingerprint !== approval.fingerprint)) {
+    throw new Error('authoring destination no longer matches the reviewed preview; no files written');
+  }
+  assertCollisions(before, allFiles, before.directory);
+
+  // A no-source plan is intentional for this release. It must still have passed the same
+  // symlink/path/collision inspection, but does not create an empty destination directory.
+  if (files.length === 0) {
+    return { directory: before.directory, fingerprint: before.fingerprint, written: [] };
+  }
+
+  await ensureDirectory(before.directory);
+  for (const file of files) {
+    await ensureDirectory(path.dirname(toOutputPath(before.directory, file.path)));
+  }
+
+  // Re-run every safety decision after creating the directory tree and immediately before any
+  // content reaches disk. This catches a changed target, link insertion, or collision.
+  const preflight = await inspectAuthoringDestination(before.directory, plan);
+  assertCollisions(preflight, files, before.directory);
+
+  const staged: Array<{ file: MaterializedFile; target: string; temporary: string }> = [];
+  try {
+    for (const file of files) {
+      const target = toOutputPath(preflight.directory, file.path);
+      const temporary = path.join(path.dirname(target), `.${path.basename(target)}.block-runner-${randomBytes(12).toString('hex')}.tmp`);
+      const handle = await open(temporary, 'wx', 0o600);
+      try {
+        await handle.writeFile(file.content, 'utf8');
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+      staged.push({ file, target, temporary });
+    }
+
+    // Staging changes directory mtimes, so the fingerprint deliberately tracks directory
+    // identity but not those mutable timestamps. Re-inspect paths and target identities here.
+    const immediatelyBeforePublish = await inspectAuthoringDestination(preflight.directory, plan);
+    if (immediatelyBeforePublish.fingerprint !== preflight.fingerprint) {
+      throw new Error('authoring destination changed before files could be written');
+    }
+    assertCollisions(immediatelyBeforePublish, files, preflight.directory);
+
+    for (const item of staged) {
+      const existing = entryFor(immediatelyBeforePublish, item.target);
+      if (existing?.kind === 'file') {
+        if (!item.file.replace) {
+          throw new Error(`planned file already exists: ${item.file.path}; add an explicit replace decision to the plan`);
+        }
+        // Rename is atomic within this verified directory. The final lstat is intentionally
+        // adjacent to publication so a different file is never silently approved for replacement.
+        const now = await lstatRegular(item.target, item.file.path);
+        if (!sameIdentity(now, existing.identity)) {
+          throw new Error(`planned file changed before replacement: ${item.file.path}`);
+        }
+        await rename(item.temporary, item.target);
+      } else {
+        // `link` has O_EXCL-like publication semantics: it cannot replace a file that appeared
+        // after preflight. It also keeps publication atomic because temp and target share a dir.
+        await link(item.temporary, item.target);
+        await unlink(item.temporary);
+      }
+    }
+
+    const after = await inspectAuthoringDestination(preflight.directory, plan);
+    return { directory: after.directory, fingerprint: after.fingerprint, written: files.map((file) => file.path) };
+  } finally {
+    await Promise.all(
+      staged.map(async ({ temporary }) => {
+        try {
+          await unlink(temporary);
+        } catch (error) {
+          if (!isNotFound(error)) {
+            throw error;
+          }
+        }
+      }),
+    );
+  }
+}
+
+/** Validate again at the filesystem boundary; schema validation alone must never be trusted for writes. */
+export function assertSafePlannedPath(value: string): string {
+  if (
+    !value ||
+    value.includes('\0') ||
+    value.includes('\\') ||
+    path.posix.isAbsolute(value) ||
+    path.win32.isAbsolute(value) ||
+    /^[A-Za-z]:/.test(value) ||
+    value !== path.posix.normalize(value)
+  ) {
+    throw new Error(`unsafe planned file path: ${JSON.stringify(value)}`);
+  }
+  const parts = value.split('/');
+  if (parts.some((part) => !part || part === '.' || part === '..')) {
+    throw new Error(`unsafe planned file path: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+async function inspectDirectoryPath(directory: string, entries: Map<string, DestinationEntry>): Promise<void> {
+  const parsed = path.parse(directory);
+  let current = parsed.root;
+  const parts = directory.slice(parsed.root.length).split(path.sep).filter(Boolean);
+  await inspectDirectoryComponent(current, entries);
+  for (const part of parts) {
+    current = path.join(current, part);
+    const entry = await inspectDirectoryComponent(current, entries);
+    if (entry.kind === 'missing') {
+      return;
+    }
+  }
+}
+
+/**
+ * macOS exposes a few root-level directories through fixed compatibility links (for example
+ * `/tmp` -> `/private/tmp`). They are not destinations a caller can create or redirect. Verify
+ * the exact platform mapping before translating it, then inspect every remaining component
+ * lexically. No caller-controlled symlink is ever followed.
+ */
+async function canonicalizeTrustedSystemAlias(outputDirectory: string): Promise<string> {
+  const directory = path.resolve(outputDirectory);
+  for (const [alias, physical] of [
+    ['/tmp', '/private/tmp'],
+    ['/var', '/private/var'],
+    ['/etc', '/private/etc'],
+  ] as const) {
+    if (directory !== alias && !directory.startsWith(`${alias}${path.sep}`)) {
+      continue;
+    }
+    const stats = await lstatMaybe(alias);
+    if (!stats?.isSymbolicLink()) {
+      return directory;
+    }
+    const target = path.resolve(path.dirname(alias), await readlink(alias));
+    if (target !== physical) {
+      throw new Error(`symbolic-link path is not allowed in authoring destination: ${alias}`);
+    }
+    return path.join(physical, path.relative(alias, directory));
+  }
+  return directory;
+}
+
+async function inspectPlannedPath(directory: string, relativePath: string, entries: Map<string, DestinationEntry>): Promise<void> {
+  const safePath = assertSafePlannedPath(relativePath);
+  let current = directory;
+  const components = safePath.split('/');
+  for (let index = 0; index < components.length; index += 1) {
+    current = path.join(current, components[index]!);
+    const final = index === components.length - 1;
+    const key = displayPath(current);
+    if (entries.has(key)) {
+      continue;
+    }
+    const stats = await lstatMaybe(current);
+    if (!stats) {
+      entries.set(key, { path: key, kind: 'missing' });
+      return;
+    }
+    if (stats.isSymbolicLink()) {
+      throw new Error(`symbolic-link path is not allowed in authoring destination: ${key}`);
+    }
+    if (!final && !stats.isDirectory()) {
+      throw new Error(`authoring destination parent is not a directory: ${key}`);
+    }
+    if (final && !stats.isFile()) {
+      throw new Error(`planned destination is not a regular file: ${relativePath}`);
+    }
+    entries.set(key, {
+      path: key,
+      kind: final ? 'file' : 'directory',
+      identity: await identityFor(current, stats, final),
+    });
+  }
+}
+
+async function inspectDirectoryComponent(directory: string, entries: Map<string, DestinationEntry>): Promise<DestinationEntry> {
+  const key = displayPath(directory);
+  const previous = entries.get(key);
+  if (previous) {
+    return previous;
+  }
+  const stats = await lstatMaybe(directory);
+  if (!stats) {
+    const missing: DestinationEntry = { path: key, kind: 'missing' };
+    entries.set(key, missing);
+    return missing;
+  }
+  if (stats.isSymbolicLink()) {
+    throw new Error(`symbolic-link path is not allowed in authoring destination: ${key}`);
+  }
+  if (!stats.isDirectory()) {
+    throw new Error(`authoring destination is not a directory: ${key}`);
+  }
+  const entry: DestinationEntry = { path: key, kind: 'directory', identity: await identityFor(directory, stats, false) };
+  entries.set(key, entry);
+  return entry;
+}
+
+async function ensureDirectory(directory: string): Promise<void> {
+  const absolute = path.resolve(directory);
+  const parsed = path.parse(absolute);
+  let current = parsed.root;
+  const parts = absolute.slice(parsed.root.length).split(path.sep).filter(Boolean);
+  for (const part of parts) {
+    current = path.join(current, part);
+    const stats = await lstatMaybe(current);
+    if (stats) {
+      if (stats.isSymbolicLink()) {
+        throw new Error(`symbolic-link path is not allowed in authoring destination: ${displayPath(current)}`);
+      }
+      if (!stats.isDirectory()) {
+        throw new Error(`authoring destination is not a directory: ${displayPath(current)}`);
+      }
+      continue;
+    }
+    await mkdir(current);
+    const created = await lstat(current);
+    if (created.isSymbolicLink() || !created.isDirectory()) {
+      throw new Error(`unsafe authoring destination directory: ${displayPath(current)}`);
+    }
+  }
+}
+
+function assertCollisions(inspection: DestinationInspection, files: Array<Pick<PlannedOutput, 'path' | 'replace'>>, directory: string): void {
+  for (const file of files) {
+    const target = toOutputPath(directory, file.path);
+    const existing = entryFor(inspection, target);
+    if (existing?.kind === 'file' && !file.replace) {
+      throw new Error(`planned file already exists: ${file.path}; add an explicit replace decision to the plan`);
+    }
+  }
+}
+
+function plannedFiles(plan: AuthoringPlan): PlannedOutput[] {
+  const maybeFiles = (plan as unknown as { files?: unknown }).files;
+  if (!Array.isArray(maybeFiles)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  return maybeFiles.map((candidate) => {
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+      throw new Error('authoring plan has an invalid planned file');
+    }
+    const value = candidate as { path?: unknown; content?: unknown; operation?: unknown };
+    if (typeof value.path !== 'string') {
+      throw new Error('authoring plan has a planned file without a path');
+    }
+    const filePath = assertSafePlannedPath(value.path);
+    if (seen.has(filePath)) {
+      throw new Error(`authoring plan has duplicate planned file path: ${filePath}`);
+    }
+    seen.add(filePath);
+    return { path: filePath, content: value.content, replace: value.operation === 'replace' };
+  });
+}
+
+function toOutputPath(directory: string, relativePath: string): string {
+  const safe = assertSafePlannedPath(relativePath);
+  const target = path.resolve(directory, ...safe.split('/'));
+  if (target !== directory && !target.startsWith(`${directory}${path.sep}`)) {
+    throw new Error(`planned file escapes output directory: ${JSON.stringify(relativePath)}`);
+  }
+  return target;
+}
+
+async function identityFor(file: string, stats: Awaited<ReturnType<typeof lstat>>, includeContent: boolean): Promise<FileIdentity> {
+  const withNs = stats as typeof stats & { mtimeNs?: bigint; ctimeNs?: bigint };
+  // Directory mtimes/ctimes change when we stage same-directory temporary files. Their stable
+  // identity is what matters for escape prevention; target regular files retain full metadata
+  // and bytes in the fingerprint.
+  const directory = stats.isDirectory();
+  return {
+    dev: String(stats.dev),
+    ino: String(stats.ino),
+    mode: Number(stats.mode),
+    size: directory ? '0' : String(stats.size),
+    mtimeNs: directory ? '0' : String(withNs.mtimeNs ?? BigInt(Math.round(Number(stats.mtimeMs) * 1_000_000))),
+    ctimeNs: directory ? '0' : String(withNs.ctimeNs ?? BigInt(Math.round(Number(stats.ctimeMs) * 1_000_000))),
+    ...(includeContent ? { sha256: hashBuffer(await readFile(file)) } : {}),
+  };
+}
+
+async function lstatRegular(file: string, plannedPath: string): Promise<FileIdentity> {
+  const stats = await lstat(file);
+  if (stats.isSymbolicLink() || !stats.isFile()) {
+    throw new Error(`planned destination is no longer a regular file: ${plannedPath}`);
+  }
+  return identityFor(file, stats, true);
+}
+
+async function lstatMaybe(file: string): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {
+  try {
+    return await lstat(file);
+  } catch (error) {
+    if (isNotFound(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function sameIdentity(left: FileIdentity, right: FileIdentity | undefined): boolean {
+  return Boolean(right) && JSON.stringify(left) === JSON.stringify(right);
+}
+
+function entryFor(inspection: DestinationInspection, absolutePath: string): DestinationEntry | undefined {
+  return inspection.entries.find((entry) => entry.path === displayPath(absolutePath));
+}
+
+function fingerprint(value: unknown): string {
+  return `sha256:${hashBuffer(Buffer.from(stableJson(value), 'utf8'))}`;
+}
+
+function hashBuffer(value: Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(',')}]`;
+  }
+  if (value !== null && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function displayPath(value: string): string {
+  return path.resolve(value);
+}
+
+function isNotFound(error: unknown): error is NodeJS.ErrnoException {
+  return typeof error === 'object' && error !== null && (error as NodeJS.ErrnoException).code === 'ENOENT';
+}

--- a/src/authoring/preview.ts
+++ b/src/authoring/preview.ts
@@ -1,0 +1,412 @@
+import { hashAuthoringPlan, type AuthoringPlan } from './schema.js';
+
+/**
+ * Extra facts collected by the caller for a particular destination.  They deliberately live
+ * outside the plan: a plan can be inspected without granting it authority to write anywhere.
+ */
+export interface AuthoringPreviewContext {
+  /** SHA-256 of the canonical plan, normally including the generator version. */
+  hash?: string;
+  /** SHA-256 confirmation that additionally binds this preview's destination snapshot. */
+  confirmationHash?: string;
+  /** Absolute or display-safe destination selected for this invocation. */
+  destination?: string;
+  /** Opaque fingerprint of the destination observed while previewing. */
+  destinationFingerprint?: string;
+}
+
+export interface AuthoringPreviewOptions extends AuthoringPreviewContext {
+  /** Terminal column count. Defaults to the current stdout width, or 80 when unavailable. */
+  width?: number;
+  /**
+   * Kept for callers which share output options with other commands. Preview intentionally emits
+   * no escape sequences, so `NO_COLOR` is always honoured and this option has no visual effect.
+   */
+  color?: boolean;
+}
+
+type RecordValue = Record<string, unknown>;
+
+/**
+ * Render an inspectable, non-interactive preview of an authoring plan.
+ *
+ * The renderer has no I/O and never emits terminal escapes. The CLI may use the same renderer for
+ * a TTY and redirected output without risking ANSI in a machine-readable channel. Its only source
+ * of nondeterminism would be a terminal width, which is an explicit option and defaults to 80 in
+ * non-terminal environments.
+ */
+export function renderAuthoringPreview(plan: AuthoringPlan, options: AuthoringPreviewOptions = {}): string {
+  const width = previewWidth(options.width);
+  const value = asRecord(plan);
+  const target = asRecord(value.target);
+  const lines: string[] = [];
+
+  heading(lines, 'Authoring plan preview', width, '=');
+  addKeyValue(lines, 'Plan version', value.version, width);
+  addKeyValue(lines, 'Generator version', value.generatorVersion, width);
+  addKeyValue(lines, 'Plan SHA-256', options.hash ?? hashAuthoringPlan(plan), width);
+  addKeyValue(lines, 'Confirmation SHA-256', options.confirmationHash, width);
+
+  section(lines, 'Target', width);
+  const namespace = readString(target, ['namespace']);
+  const name = readString(target, ['name']);
+  addKeyValue(lines, 'Block', namespace && name ? `${namespace}/${name}` : name || namespace, width);
+  addKeyValue(lines, 'Title', target.title, width);
+  addKeyValue(lines, 'Description', target.description, width);
+  addKeyValue(lines, 'Category', target.category, width);
+  addKeyValue(lines, 'Icon', target.icon, width);
+  addKeyValue(lines, 'Text domain', target.textDomain ?? target.textdomain, width);
+  addKeyValue(lines, 'WordPress', target.wordpress, width);
+  const destination = options.destination ?? readString(target, ['directory', 'destination', 'outputDir']);
+  addKeyValue(lines, 'Destination', destination, width);
+  addKeyValue(lines, 'Destination fingerprint', options.destinationFingerprint, width);
+
+  section(lines, 'Structure', width);
+  const structure = asArray(value.structure);
+  if (structure.length === 0) {
+    bullet(lines, 'none', width);
+  } else {
+    structure.forEach((node, index) => renderStructureNode(lines, node, '', index === structure.length - 1, width));
+  }
+  const locking = asRecord(value.locking);
+  if (Object.keys(locking).length > 0) {
+    bullet(lines, `locking: ${describeLocking(locking)}`, width);
+  }
+
+  section(lines, 'Editable fields', width);
+  const fields = asArray(value.fields);
+  if (fields.length === 0) {
+    bullet(lines, 'none', width);
+  } else {
+    fields.forEach((field, index) => bullet(lines, describeField(field, index), width));
+  }
+
+  section(lines, 'Style outcomes', width);
+  const styles = asRecord(value.styles);
+  const strategy = readString(styles, ['strategy']);
+  if (strategy) {
+    bullet(lines, `strategy: ${strategy}`, width);
+  }
+  const outcomes = asArray(styles.outcomes);
+  if (outcomes.length === 0) {
+    bullet(lines, 'none', width);
+  } else {
+    outcomes.forEach((outcome, index) => bullet(lines, describeStyleOutcome(outcome, index), width));
+  }
+
+  section(lines, 'Assets', width);
+  const assets = asArray(value.assets);
+  if (assets.length === 0) {
+    bullet(lines, 'none', width);
+  } else {
+    assets.forEach((asset, index) => bullet(lines, describeAsset(asset, index), width));
+  }
+
+  section(lines, 'Pattern readiness', width);
+  const pattern = asRecord(value.pattern);
+  const ready = pattern.ready;
+  bullet(lines, ready === true ? 'ready' : ready === false ? 'not ready' : 'not specified', width);
+  const overrides = asArray(pattern.overrides);
+  if (overrides.length === 0) {
+    bullet(lines, 'overrides: none', width);
+  } else {
+    overrides.forEach((override, index) => bullet(lines, `[override] ${describeItem(override, index)}`, width));
+  }
+
+  section(lines, 'Planned files', width);
+  const files = asArray(value.files);
+  if (files.length === 0) {
+    bullet(lines, 'none', width);
+  } else {
+    files.forEach((file, index) => bullet(lines, describeFile(file, index), width));
+  }
+
+  section(lines, 'Warnings', width);
+  const warnings = asArray(value.warnings);
+  if (warnings.length === 0) {
+    bullet(lines, 'none', width);
+  } else {
+    warnings.forEach((warning) => bullet(lines, plain(warning), width));
+  }
+
+  section(lines, 'Write status', width);
+  bullet(lines, 'No files written.', width);
+
+  return `${lines.join('\n')}\n`;
+}
+
+/** Alias kept concise for programmatic consumers. */
+export const previewAuthoringPlan = renderAuthoringPreview;
+
+function renderStructureNode(lines: string[], value: unknown, prefix: string, last: boolean, width: number): void {
+  const node = asRecord(value);
+  const branch = prefix ? `${prefix}${last ? '`- ' : '|- '}` : '- ';
+  const block = readString(node, ['block', 'name', 'type']) ?? 'unnamed block';
+  const label = readString(node, ['label']);
+  const id = readString(node, ['id']);
+  const identity = [
+    label && label !== block ? `${block} (${label})` : block,
+    id ? `#${id}` : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const annotations = structureAnnotations(node);
+  wrapped(lines, `${branch}${identity}${annotations.length > 0 ? ` ${annotations.join(' ')}` : ''}`, width, prefix ? `${prefix}${last ? '   ' : '|  '}` : '  ');
+
+  const children = asArray(node.children ?? node.innerBlocks);
+  const nextPrefix = prefix ? `${prefix}${last ? '   ' : '|  '}` : '  ';
+  if (node.attributes !== undefined) {
+    wrapped(lines, `${nextPrefix}attributes: ${stableJson(node.attributes)}`, width, `${nextPrefix}  `);
+  }
+  children.forEach((child, index) => renderStructureNode(lines, child, nextPrefix, index === children.length - 1, width));
+}
+
+function structureAnnotations(node: RecordValue): string[] {
+  const annotations: string[] = [];
+  const state = readString(node, ['mode', 'role', 'state']);
+  if (state && isFieldMode(state)) {
+    annotations.push(`[${state}]`);
+  } else if (node.locked === true || node.editable === false) {
+    annotations.push('[fixed]');
+  } else if (node.editable === true) {
+    annotations.push('[editable]');
+  }
+  if (node.locked === true && !annotations.includes('[fixed]')) {
+    annotations.push('[locked]');
+  }
+  const lock = asRecord(node.lock);
+  if (Object.keys(lock).length > 0) {
+    const operations: string[] = [];
+    if (typeof lock.move === 'boolean') {
+      operations.push(`move=${lock.move ? 'allowed' : 'blocked'}`);
+    }
+    if (typeof lock.remove === 'boolean') {
+      operations.push(`remove=${lock.remove ? 'allowed' : 'blocked'}`);
+    }
+    if (operations.length > 0) {
+      annotations.push(`[${operations.join(',')}]`);
+    }
+  }
+  return annotations;
+}
+
+function describeLocking(locking: RecordValue): string {
+  const mode = readString(locking, ['mode']) ?? 'not specified';
+  const permissions: string[] = [];
+  for (const [name, enabled] of [
+    ['move', locking.move ?? locking.allowMove],
+    ['remove', locking.remove ?? locking.allowRemove],
+    ['insert', locking.insert ?? locking.allowInsert],
+  ] as Array<[string, unknown]>) {
+    if (typeof enabled === 'boolean') {
+      permissions.push(`${name}=${enabled ? 'allowed' : 'blocked'}`);
+    }
+  }
+  return permissions.length > 0 ? `${mode} (${permissions.join(', ')})` : mode;
+}
+
+function describeField(value: unknown, index: number): string {
+  const field = asRecord(value);
+  const mode = fieldMode(field);
+  const id = readString(field, ['id', 'name', 'key']);
+  const label = readString(field, ['label']);
+  const name = label && label !== id ? `${label} (${id})` : label ?? id ?? `field ${index + 1}`;
+  const type = readString(field, ['type', 'fieldType', 'kind']);
+  const path = readString(field, ['path', 'attribute', 'bind', 'binding']);
+  const node = readString(field, ['node']);
+  const description = readString(field, ['description', 'help']);
+  const defaultValue = field.default ?? field.defaultValue;
+  const details = [
+    type && !isFieldMode(type) ? type : undefined,
+    node ? `node ${node}` : undefined,
+    path ? `at ${path}` : undefined,
+    defaultValue === undefined ? undefined : `default ${describeScalar(defaultValue)}`,
+    description,
+  ].filter((part): part is string => Boolean(part));
+  return `[${mode}] ${name}${details.length > 0 ? ` - ${details.join('; ')}` : ''}`;
+}
+
+function describeStyleOutcome(value: unknown, index: number): string {
+  const outcome = asRecord(value);
+  const subject = readString(outcome, ['property', 'source', 'name', 'selector', 'id']) ?? `style ${index + 1}`;
+  const result = readString(outcome, ['outcome', 'result', 'handling', 'destination', 'value']);
+  const styleValue = readString(outcome, ['value']);
+  const token = readString(outcome, ['token']);
+  const reason = readString(outcome, ['reason', 'note', 'detail']);
+  return [
+    subject,
+    result && result !== subject ? `-> ${result}` : undefined,
+    token ? `token ${token}` : undefined,
+    styleValue && styleValue !== result ? `value ${styleValue}` : undefined,
+    reason,
+  ]
+    .filter(Boolean)
+    .join('; ');
+}
+
+function describeAsset(value: unknown, index: number): string {
+  const asset = asRecord(value);
+  const source = readString(asset, ['source', 'path', 'url', 'name', 'id']) ?? `asset ${index + 1}`;
+  const destination = readString(asset, ['destination', 'output', 'target']);
+  const kind = readString(asset, ['kind', 'type']);
+  const status = readString(asset, ['status']);
+  const required = asset.required === true ? 'required' : asset.required === false ? 'optional' : undefined;
+  return [
+    kind ? `[${kind}] ${source}` : source,
+    destination ? `-> ${destination}` : undefined,
+    status ? `[${status}]` : undefined,
+    required ? `[${required}]` : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function describeFile(value: unknown, index: number): string {
+  const file = asRecord(value);
+  const path = readString(file, ['path', 'destination', 'name']) ?? `file ${index + 1}`;
+  const kind = readString(file, ['kind', 'type']);
+  const replacement =
+    readString(file, ['operation', 'disposition', 'action']) ?? (file.replace === true || file.overwrite === true ? 'replace' : 'create');
+  return `${path}${kind ? ` [${kind}]` : ''} [${replacement}]`;
+}
+
+function describeItem(value: unknown, index: number): string {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return plain(value);
+  }
+  const item = asRecord(value);
+  const primary = readString(item, ['name', 'path', 'field', 'id', 'source', 'property']) ?? `item ${index + 1}`;
+  const label = readString(item, ['label']);
+  const identity = label && label !== primary ? `${label} (${primary})` : primary;
+  const secondary = readString(item, ['description', 'target', 'attribute', 'value', 'reason']);
+  return secondary && secondary !== identity ? `${identity} - ${secondary}` : identity;
+}
+
+function fieldMode(field: RecordValue): 'fixed' | 'editable' | 'override' {
+  const supplied = readString(field, ['mode', 'role', 'state', 'editability']);
+  if (supplied && isFieldMode(supplied)) {
+    return supplied;
+  }
+  if (field.overridable === true || field.override === true) {
+    return 'override';
+  }
+  return field.editable === false || field.locked === true ? 'fixed' : 'editable';
+}
+
+function isFieldMode(value: string): value is 'fixed' | 'editable' | 'override' {
+  return value === 'fixed' || value === 'editable' || value === 'override';
+}
+
+function heading(lines: string[], label: string, width: number, fill: '=' | '-'): void {
+  wrapped(lines, label, width, '');
+  lines.push(fill.repeat(Math.max(1, Math.min(width, label.length))));
+}
+
+function section(lines: string[], label: string, width: number): void {
+  lines.push('');
+  heading(lines, label, width, '-');
+}
+
+function addKeyValue(lines: string[], key: string, value: unknown, width: number): void {
+  if (value === undefined || value === null || value === '') {
+    return;
+  }
+  wrapped(lines, `${key}: ${describeScalar(value)}`, width, '  ');
+}
+
+function bullet(lines: string[], value: string, width: number): void {
+  wrapped(lines, `- ${value}`, width, '  ');
+}
+
+function wrapped(lines: string[], value: string, width: number, continuation: string): void {
+  // `plain` intentionally trims untrusted values; retain only renderer-owned leading spaces so
+  // the ASCII tree remains a tree while plan text cannot manufacture indentation or controls.
+  const indentation = /^ */.exec(value)?.[0] ?? '';
+  const text = `${indentation}${plain(value.slice(indentation.length))}`;
+  if (text.length <= width) {
+    lines.push(text);
+    return;
+  }
+
+  const firstBreak = preferredBreak(text, width);
+  lines.push(text.slice(0, firstBreak));
+  let rest = text.slice(firstBreak).trimStart();
+  // At exceptionally narrow widths preserving tree/list indentation would itself exceed the
+  // terminal. Dropping it is preferable to emitting a line wider than requested.
+  const continuationPrefix = continuation.length < width ? continuation : '';
+  const available = Math.max(1, width - continuationPrefix.length);
+  while (rest.length > available) {
+    const breakAt = preferredBreak(rest, available);
+    lines.push(`${continuationPrefix}${rest.slice(0, breakAt)}`);
+    rest = rest.slice(breakAt).trimStart();
+  }
+  lines.push(`${continuationPrefix}${rest}`);
+}
+
+function preferredBreak(value: string, width: number): number {
+  if (value.length <= width) {
+    return value.length;
+  }
+  const space = value.lastIndexOf(' ', width);
+  return space > 0 ? space : Math.max(1, width);
+}
+
+function previewWidth(width: number | undefined): number {
+  const terminalWidth = typeof process !== 'undefined' ? process.stdout.columns : undefined;
+  const requested = width ?? terminalWidth ?? 80;
+  if (!Number.isFinite(requested)) {
+    return 80;
+  }
+  return Math.max(1, Math.floor(requested));
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asRecord(value: unknown): RecordValue {
+  return value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as RecordValue) : {};
+}
+
+function readString(record: RecordValue, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.length > 0) {
+      return plain(value);
+    }
+  }
+  return undefined;
+}
+
+function describeScalar(value: unknown): string {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return plain(value);
+  }
+  if (value === null) {
+    return 'null';
+  }
+  return stableJson(value);
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(', ')}]`;
+  }
+  if (value !== null && typeof value === 'object') {
+    const record = value as RecordValue;
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+      .join(', ')}}`;
+  }
+  return JSON.stringify(value) ?? 'undefined';
+}
+
+/** Remove escape/control bytes so plan content can never inject terminal formatting. */
+function plain(value: unknown): string {
+  return String(value)
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/[\x00-\x1f\x7f]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/src/authoring/schema.ts
+++ b/src/authoring/schema.ts
@@ -1,0 +1,592 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
+/** The only AuthoringPlan wire format accepted by this preview release. */
+export const AUTHORING_PLAN_VERSION = 1 as const;
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export type AuthoringFieldMode = 'fixed' | 'editable' | 'override';
+export type AuthoringStyleStrategy = 'native' | 'scoped-css' | 'mixed';
+export type AuthoringStyleOutcomeKind = 'native' | 'token' | 'scoped-css' | 'dropped';
+export type AuthoringAssetStatus = 'ready' | 'missing' | 'external';
+export type AuthoringFileOperation = 'create' | 'replace';
+export type AuthoringLockMode = 'all' | 'contentOnly' | 'none';
+
+/**
+ * The registered block this plan is intended to create. `directory` is a safe relative suggested
+ * package location used when preview has no explicit `--output-dir`; an explicit CLI destination
+ * always takes precedence so its previewed path can be passed unchanged to `author write`.
+ */
+export interface AuthoringTarget {
+  /** WordPress block name, for example `my-plugin/feature-grid`. */
+  name: string;
+  title: string;
+  description?: string;
+  category?: string;
+  icon?: string;
+  textDomain?: string;
+  wordpress?: string;
+  directory?: string;
+}
+
+export interface AuthoringNodeLock {
+  move?: boolean;
+  remove?: boolean;
+}
+
+/** A native block and its native children; this is never HTML. */
+export interface AuthoringStructureNode {
+  /** Optional stable reference used by a field's `node` property. */
+  id?: string;
+  block: string;
+  label?: string;
+  attributes?: { [key: string]: JsonValue };
+  lock?: AuthoringNodeLock;
+  children?: AuthoringStructureNode[];
+}
+
+/** A value an editor can, cannot, or may override in a pattern. */
+export interface AuthoringField {
+  id: string;
+  label: string;
+  mode: AuthoringFieldMode;
+  type?: string;
+  node?: string;
+  attribute?: string;
+  default?: JsonValue;
+  description?: string;
+}
+
+/** Locking that applies to the authored block as a whole. */
+export interface AuthoringLocking {
+  mode: AuthoringLockMode;
+  move?: boolean;
+  remove?: boolean;
+  insert?: boolean;
+}
+
+/** The disposition of one source style after native-style mapping. */
+export interface AuthoringStyleOutcome {
+  property: string;
+  outcome: AuthoringStyleOutcomeKind;
+  value?: string;
+  token?: string;
+  reason?: string;
+}
+
+export interface AuthoringStyles {
+  strategy: AuthoringStyleStrategy;
+  outcomes: AuthoringStyleOutcome[];
+}
+
+export interface AuthoringPatternOverride {
+  field: string;
+  label?: string;
+  description?: string;
+}
+
+export interface AuthoringPattern {
+  ready: boolean;
+  overrides: AuthoringPatternOverride[];
+}
+
+export interface AuthoringAsset {
+  id: string;
+  source: string;
+  kind?: string;
+  /** A path below the generated package, when the asset is copied into it. */
+  destination?: string;
+  status?: AuthoringAssetStatus;
+  required?: boolean;
+}
+
+/**
+ * A prospective generated file. Source generation is intentionally outside the preview: `content`
+ * is therefore optional, but when supplied it is hash-bound just like every other plan decision.
+ */
+export interface AuthoringFile {
+  /** Portable, relative POSIX path below the output directory. */
+  path: string;
+  kind?: string;
+  content?: string;
+  /** Replacing a collision requires this separate explicit, hash-bound plan decision. */
+  operation?: AuthoringFileOperation;
+}
+
+/**
+ * A complete, declarative input to registered-block authoring.
+ *
+ * The contract keeps human decisions separate from generated source: the structure and editor
+ * model are explicit, while files describe intended outputs and may carry materialized content
+ * only when another deterministic producer supplied it.
+ */
+export interface AuthoringPlan {
+  version: typeof AUTHORING_PLAN_VERSION;
+  generatorVersion: string;
+  target: AuthoringTarget;
+  structure: AuthoringStructureNode[];
+  fields: AuthoringField[];
+  locking: AuthoringLocking;
+  styles: AuthoringStyles;
+  pattern: AuthoringPattern;
+  assets: AuthoringAsset[];
+  files: AuthoringFile[];
+  warnings: string[];
+}
+
+export class AuthoringPlanValidationError extends Error {
+  constructor(message: string) {
+    super(`invalid authoring plan: ${message}`);
+    this.name = 'AuthoringPlanValidationError';
+  }
+}
+
+/**
+ * Parse (when necessary), validate, and normalize an untrusted AuthoringPlan.
+ *
+ * Normalization fills the deliberately boring defaults, rejects unknown fields, and returns a
+ * fresh JSON-only value. It is also the single gate used by hashing and rendering, so a preview
+ * cannot accidentally describe a different object from the one that is confirmed later.
+ */
+export function validateAuthoringPlan(input: unknown): AuthoringPlan {
+  return normalizePlan(parseInput(input));
+}
+
+/**
+ * Validate and return a recursively key-sorted plan object. Array order is deliberately retained:
+ * it describes native child order and is therefore material. Use `serializeAuthoringPlan` when a
+ * wire representation is required.
+ */
+export function canonicalizeAuthoringPlan(input: unknown): AuthoringPlan {
+  return sortJson(validateAuthoringPlan(input) as unknown as JsonValue) as unknown as AuthoringPlan;
+}
+
+/** Stable canonical JSON, with recursively sorted object keys and preserved array order. */
+export function serializeAuthoringPlan(input: unknown): string {
+  // `AuthoringPlan` is structurally JSON data, but its named interface intentionally does not
+  // have a catch-all index signature. Keep that implementation detail out of the public type.
+  return JSON.stringify(canonicalizeAuthoringPlan(input));
+}
+
+/** SHA-256 of canonical JSON, as lower-case hexadecimal (without a display-only prefix). */
+export function hashAuthoringPlan(input: unknown): string {
+  return createHash('sha256').update(serializeAuthoringPlan(input)).digest('hex');
+}
+
+/** Kept explicit for consumers which refer to the value as a canonical plan hash. */
+export const canonicalAuthoringPlanJson = serializeAuthoringPlan;
+export const canonicalAuthoringPlanHash = hashAuthoringPlan;
+
+/**
+ * Plan paths are portable paths inside an output root. They cannot select a parent, an absolute
+ * location, a Windows drive/UNC path, or an empty component that normalisation could reinterpret.
+ */
+export function isSafeAuthoringRelativePath(value: string, options: { allowDot?: boolean } = {}): boolean {
+  if (typeof value !== 'string' || value.length === 0 || value.includes('\0') || value.includes('\\')) {
+    return false;
+  }
+  if (value === '.') {
+    return options.allowDot === true;
+  }
+  // `C:relative` is not absolute according to Node, but is resolved against a per-drive
+  // working directory on Windows, so it is not a portable child path either.
+  if (path.posix.isAbsolute(value) || path.win32.isAbsolute(value) || /^[A-Za-z]:/.test(value)) {
+    return false;
+  }
+  const parts = value.split('/');
+  return parts.every((part) => part.length > 0 && part !== '.' && part !== '..');
+}
+
+function parseInput(input: unknown): unknown {
+  if (typeof input !== 'string') {
+    return input;
+  }
+  try {
+    return JSON.parse(input) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw invalid('$', `could not parse JSON (${message})`);
+  }
+}
+
+function normalizePlan(input: unknown): AuthoringPlan {
+  const value = objectAt(input, '$');
+  knownKeys(
+    value,
+    '$',
+    [
+      'version',
+      'generatorVersion',
+      'target',
+      'structure',
+      'fields',
+      'locking',
+      'styles',
+      'pattern',
+      'assets',
+      'files',
+      // `plannedFiles` is accepted only as a migration-friendly input spelling. Canonical JSON
+      // always uses `files`, so a plan receives exactly one confirmation hash.
+      'plannedFiles',
+      'warnings',
+    ],
+  );
+  if (value.version !== AUTHORING_PLAN_VERSION) {
+    throw invalid('$.version', `must be ${AUTHORING_PLAN_VERSION}`);
+  }
+  if ('files' in value && 'plannedFiles' in value) {
+    throw invalid('$', 'must not contain both files and plannedFiles');
+  }
+
+  const filesInput = value.files ?? value.plannedFiles ?? [];
+  const structure = arrayAt(value.structure ?? [], '$.structure').map((node, index) =>
+    normalizeNode(node, `$.structure[${index}]`),
+  );
+  const fields = arrayAt(value.fields ?? [], '$.fields').map((field, index) =>
+    normalizeField(field, `$.fields[${index}]`),
+  );
+  const assets = arrayAt(value.assets ?? [], '$.assets').map((asset, index) =>
+    normalizeAsset(asset, `$.assets[${index}]`),
+  );
+  const files = arrayAt(filesInput, '$.files').map((file, index) => normalizeFile(file, `$.files[${index}]`));
+
+  unique(structureNodeIds(structure), '$.structure', 'node id');
+  unique(fields.map((field) => field.id), '$.fields', 'field id');
+  unique(assets.map((asset) => asset.id), '$.assets', 'asset id');
+  unique(files.map((file) => file.path), '$.files', 'file path');
+  rejectFilePathPrefixes(files.map((file) => file.path));
+
+  return {
+    version: AUTHORING_PLAN_VERSION,
+    generatorVersion: nonEmptyString(value.generatorVersion, '$.generatorVersion'),
+    target: normalizeTarget(value.target, '$.target'),
+    structure,
+    fields,
+    locking: normalizeLocking(value.locking ?? {}, '$.locking'),
+    styles: normalizeStyles(value.styles ?? {}, '$.styles'),
+    pattern: normalizePattern(value.pattern ?? {}, '$.pattern'),
+    assets,
+    files,
+    warnings: arrayAt(value.warnings ?? [], '$.warnings').map((warning, index) =>
+      nonEmptyString(warning, `$.warnings[${index}]`),
+    ),
+  };
+}
+
+function normalizeTarget(input: unknown, location: string): AuthoringTarget {
+  const value = objectAt(input, location);
+  knownKeys(value, location, ['name', 'title', 'description', 'category', 'icon', 'textDomain', 'wordpress', 'directory']);
+  const name = nonEmptyString(value.name, `${location}.name`);
+  if (!/^[a-z0-9][a-z0-9-]*\/[a-z0-9][a-z0-9-]*$/.test(name)) {
+    throw invalid(`${location}.name`, 'must be a lowercase WordPress block name such as my-plugin/feature-grid');
+  }
+  const directory = optionalString(value.directory, `${location}.directory`);
+  if (directory !== undefined && !isSafeAuthoringRelativePath(directory, { allowDot: true })) {
+    throw invalid(`${location}.directory`, 'must be a safe relative path');
+  }
+  return withOptional({
+    name,
+    title: nonEmptyString(value.title, `${location}.title`),
+    description: optionalString(value.description, `${location}.description`),
+    category: optionalString(value.category, `${location}.category`),
+    icon: optionalString(value.icon, `${location}.icon`),
+    textDomain: optionalString(value.textDomain, `${location}.textDomain`),
+    wordpress: optionalString(value.wordpress, `${location}.wordpress`),
+    directory,
+  });
+}
+
+function normalizeNode(input: unknown, location: string): AuthoringStructureNode {
+  const value = objectAt(input, location);
+  knownKeys(value, location, ['id', 'block', 'label', 'attributes', 'lock', 'children']);
+  const attributes = value.attributes === undefined ? undefined : jsonObjectAt(value.attributes, `${location}.attributes`);
+  const children = value.children === undefined
+    ? undefined
+    : arrayAt(value.children, `${location}.children`).map((child, index) =>
+      normalizeNode(child, `${location}.children[${index}]`),
+    );
+  return withOptional({
+    id: optionalString(value.id, `${location}.id`),
+    block: nonEmptyString(value.block, `${location}.block`),
+    label: optionalString(value.label, `${location}.label`),
+    attributes,
+    lock: value.lock === undefined ? undefined : normalizeNodeLock(value.lock, `${location}.lock`),
+    children,
+  });
+}
+
+function normalizeNodeLock(input: unknown, location: string): AuthoringNodeLock {
+  const value = objectAt(input, location);
+  knownKeys(value, location, ['move', 'remove']);
+  return withOptional({
+    move: optionalBoolean(value.move, `${location}.move`),
+    remove: optionalBoolean(value.remove, `${location}.remove`),
+  });
+}
+
+function normalizeField(input: unknown, location: string): AuthoringField {
+  const value = objectAt(input, location);
+  knownKeys(value, location, ['id', 'label', 'mode', 'type', 'node', 'attribute', 'default', 'description']);
+  const mode = enumAt(value.mode, `${location}.mode`, ['fixed', 'editable', 'override'] as const);
+  return withOptional({
+    id: nonEmptyString(value.id, `${location}.id`),
+    label: nonEmptyString(value.label, `${location}.label`),
+    mode,
+    type: optionalString(value.type, `${location}.type`),
+    node: optionalString(value.node, `${location}.node`),
+    attribute: optionalString(value.attribute, `${location}.attribute`),
+    default: value.default === undefined ? undefined : jsonAt(value.default, `${location}.default`),
+    description: optionalString(value.description, `${location}.description`),
+  });
+}
+
+function normalizeLocking(input: unknown, location: string): AuthoringLocking {
+  const value = objectAt(input, location);
+  knownKeys(value, location, ['mode', 'move', 'remove', 'insert']);
+  return withOptional({
+    mode: value.mode === undefined
+      ? 'none'
+      : enumAt(value.mode, `${location}.mode`, ['all', 'contentOnly', 'none'] as const),
+    move: optionalBoolean(value.move, `${location}.move`),
+    remove: optionalBoolean(value.remove, `${location}.remove`),
+    insert: optionalBoolean(value.insert, `${location}.insert`),
+  });
+}
+
+function normalizeStyles(input: unknown, location: string): AuthoringStyles {
+  const value = objectAt(input, location);
+  knownKeys(value, location, ['strategy', 'outcomes']);
+  return {
+    strategy: value.strategy === undefined
+      ? 'native'
+      : enumAt(value.strategy, `${location}.strategy`, ['native', 'scoped-css', 'mixed'] as const),
+    outcomes: arrayAt(value.outcomes ?? [], `${location}.outcomes`).map((outcome, index) =>
+      normalizeStyleOutcome(outcome, `${location}.outcomes[${index}]`),
+    ),
+  };
+}
+
+function normalizeStyleOutcome(input: unknown, location: string): AuthoringStyleOutcome {
+  const value = objectAt(input, location);
+  knownKeys(value, location, ['property', 'outcome', 'value', 'token', 'reason']);
+  return withOptional({
+    property: nonEmptyString(value.property, `${location}.property`),
+    outcome: enumAt(value.outcome, `${location}.outcome`, ['native', 'token', 'scoped-css', 'dropped'] as const),
+    value: optionalString(value.value, `${location}.value`),
+    token: optionalString(value.token, `${location}.token`),
+    reason: optionalString(value.reason, `${location}.reason`),
+  });
+}
+
+function normalizePattern(input: unknown, location: string): AuthoringPattern {
+  const value = objectAt(input, location);
+  knownKeys(value, location, ['ready', 'overrides']);
+  return {
+    ready: value.ready === undefined ? false : booleanAt(value.ready, `${location}.ready`),
+    overrides: arrayAt(value.overrides ?? [], `${location}.overrides`).map((override, index) => {
+      const itemLocation = `${location}.overrides[${index}]`;
+      const item = objectAt(override, itemLocation);
+      knownKeys(item, itemLocation, ['field', 'label', 'description']);
+      return withOptional({
+        field: nonEmptyString(item.field, `${itemLocation}.field`),
+        label: optionalString(item.label, `${itemLocation}.label`),
+        description: optionalString(item.description, `${itemLocation}.description`),
+      });
+    }),
+  };
+}
+
+function normalizeAsset(input: unknown, location: string): AuthoringAsset {
+  const value = objectAt(input, location);
+  knownKeys(value, location, ['id', 'source', 'kind', 'destination', 'status', 'required']);
+  const destination = optionalString(value.destination, `${location}.destination`);
+  if (destination !== undefined && !isSafeAuthoringRelativePath(destination)) {
+    throw invalid(`${location}.destination`, 'must be a safe relative path');
+  }
+  return withOptional({
+    id: nonEmptyString(value.id, `${location}.id`),
+    source: nonEmptyString(value.source, `${location}.source`),
+    kind: optionalString(value.kind, `${location}.kind`),
+    destination,
+    status: value.status === undefined
+      ? undefined
+      : enumAt(value.status, `${location}.status`, ['ready', 'missing', 'external'] as const),
+    required: optionalBoolean(value.required, `${location}.required`),
+  });
+}
+
+function normalizeFile(input: unknown, location: string): AuthoringFile {
+  const value = objectAt(input, location);
+  knownKeys(value, location, ['path', 'kind', 'content', 'operation']);
+  const filePath = nonEmptyString(value.path, `${location}.path`);
+  if (!isSafeAuthoringRelativePath(filePath)) {
+    throw invalid(`${location}.path`, 'must be a safe relative path');
+  }
+  return withOptional({
+    path: filePath,
+    kind: optionalString(value.kind, `${location}.kind`),
+    content: optionalString(value.content, `${location}.content`, { allowEmpty: true }),
+    operation: value.operation === undefined
+      ? undefined
+      : enumAt(value.operation, `${location}.operation`, ['create', 'replace'] as const),
+  });
+}
+
+function structureNodeIds(nodes: AuthoringStructureNode[]): string[] {
+  const ids: string[] = [];
+  const visit = (node: AuthoringStructureNode): void => {
+    if (node.id !== undefined) {
+      ids.push(node.id);
+    }
+    for (const child of node.children ?? []) {
+      visit(child);
+    }
+  };
+  for (const node of nodes) {
+    visit(node);
+  }
+  return ids;
+}
+
+function unique(values: string[], location: string, kind: string): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      throw invalid(location, `contains duplicate ${kind} ${JSON.stringify(value)}`);
+    }
+    seen.add(value);
+  }
+}
+
+function rejectFilePathPrefixes(paths: string[]): void {
+  const ordered = [...paths].sort();
+  for (let index = 1; index < ordered.length; index += 1) {
+    const previous = ordered[index - 1]!;
+    const current = ordered[index]!;
+    if (current.startsWith(`${previous}/`)) {
+      throw invalid('$.files', `cannot contain both file ${JSON.stringify(previous)} and its descendant ${JSON.stringify(current)}`);
+    }
+  }
+}
+
+function objectAt(input: unknown, location: string): Record<string, unknown> {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw invalid(location, 'must be an object');
+  }
+  return input as Record<string, unknown>;
+}
+
+function jsonObjectAt(input: unknown, location: string): { [key: string]: JsonValue } {
+  const object = objectAt(input, location);
+  const output: { [key: string]: JsonValue } = Object.create(null) as { [key: string]: JsonValue };
+  for (const key of Object.keys(object)) {
+    output[key] = jsonAt(object[key], `${location}.${key}`);
+  }
+  return output;
+}
+
+function arrayAt(input: unknown, location: string): unknown[] {
+  if (!Array.isArray(input)) {
+    throw invalid(location, 'must be an array');
+  }
+  return input;
+}
+
+function jsonAt(input: unknown, location: string): JsonValue {
+  if (input === null || typeof input === 'string' || typeof input === 'boolean') {
+    return input;
+  }
+  if (typeof input === 'number') {
+    if (!Number.isFinite(input)) {
+      throw invalid(location, 'must be a finite JSON number');
+    }
+    return input;
+  }
+  if (Array.isArray(input)) {
+    return input.map((value, index) => jsonAt(value, `${location}[${index}]`));
+  }
+  if (input && typeof input === 'object') {
+    return jsonObjectAt(input, location);
+  }
+  throw invalid(location, 'must be JSON data');
+}
+
+function knownKeys(value: Record<string, unknown>, location: string, allowed: string[]): void {
+  const known = new Set(allowed);
+  for (const key of Object.keys(value)) {
+    if (!known.has(key)) {
+      throw invalid(`${location}.${key}`, 'is not part of AuthoringPlan v1');
+    }
+  }
+}
+
+function nonEmptyString(input: unknown, location: string): string {
+  const value = stringAt(input, location);
+  if (value.trim().length === 0) {
+    throw invalid(location, 'must not be empty');
+  }
+  return value;
+}
+
+function optionalString(input: unknown, location: string, options: { allowEmpty?: boolean } = {}): string | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+  const value = stringAt(input, location);
+  if (!options.allowEmpty && value.trim().length === 0) {
+    throw invalid(location, 'must not be empty');
+  }
+  return value;
+}
+
+function stringAt(input: unknown, location: string): string {
+  if (typeof input !== 'string') {
+    throw invalid(location, 'must be a string');
+  }
+  return input;
+}
+
+function optionalBoolean(input: unknown, location: string): boolean | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+  return booleanAt(input, location);
+}
+
+function booleanAt(input: unknown, location: string): boolean {
+  if (typeof input !== 'boolean') {
+    throw invalid(location, 'must be a boolean');
+  }
+  return input;
+}
+
+function enumAt<T extends readonly string[]>(input: unknown, location: string, allowed: T): T[number] {
+  if (typeof input !== 'string' || !allowed.includes(input)) {
+    throw invalid(location, `must be one of ${allowed.map((value) => JSON.stringify(value)).join(', ')}`);
+  }
+  return input as T[number];
+}
+
+function withOptional<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined)) as T;
+}
+
+function sortJson<T extends JsonValue>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortJson(item)) as T;
+  }
+  if (value && typeof value === 'object') {
+    const output: { [key: string]: JsonValue } = Object.create(null) as { [key: string]: JsonValue };
+    for (const key of Object.keys(value).sort()) {
+      output[key] = sortJson(value[key]!);
+    }
+    return output as T;
+  }
+  return value;
+}
+
+function invalid(location: string, message: string): AuthoringPlanValidationError {
+  return new AuthoringPlanValidationError(`${location} ${message}`);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { createRequire } from 'node:module';
 import { existsSync } from 'node:fs';
-import { readFile, writeFile } from 'node:fs/promises';
+import { lstat, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
@@ -15,6 +15,9 @@ import { loadConfig } from './config/load.js';
 import { collectSiteContext } from './context/run.js';
 import { installCanonicalSkill, readCanonicalSkillGuide, SkillScope, SkillTarget } from './skill.js';
 import { BlockRunnerReport, CommonOptions, HeadlessBootError } from './types.js';
+import { hashAuthoringConfirmation, inspectAuthoringDestination, writeAuthoringPlan } from './authoring/destination.js';
+import { hashAuthoringPlan, serializeAuthoringPlan, validateAuthoringPlan } from './authoring/schema.js';
+import { renderAuthoringPreview } from './authoring/preview.js';
 
 const { version: packageVersion } = createRequire(import.meta.url)('../package.json') as {
   version: string;
@@ -44,6 +47,18 @@ interface SkillCliOptions {
   target?: SkillTarget;
   dryRun?: boolean;
   force?: boolean;
+}
+
+interface AuthorPreviewCliOptions {
+  json?: boolean;
+  outputDir?: string;
+  width?: string;
+}
+
+interface AuthorWriteCliOptions {
+  confirm?: string;
+  outputDir?: string;
+  json?: boolean;
 }
 
 const program = new Command();
@@ -246,6 +261,99 @@ program
     }
   });
 
+const author = program.command('author').description('Review and materialize a versioned registered-block authoring plan.');
+
+author
+  .command('preview <planOrStdin>')
+  .description('Validate and render an authoring plan without writing files.')
+  .option('--output-dir <dir>', 'exact destination directory to fingerprint (default: plan directory or current directory)')
+  .option('--width <columns>', 'preview width in terminal columns')
+  .option('--json', 'emit a machine-readable preview')
+  .action(async (planOrStdin: string, options: AuthorPreviewCliOptions) => {
+    const plan = validateAuthoringPlan(await readAuthoringPlan(planOrStdin));
+    const hash = hashAuthoringPlan(plan);
+    const destination = authoringDestination(options.outputDir, plan.target.directory);
+    const inspection = await inspectAuthoringDestination(destination, plan);
+    const confirmation = hashAuthoringConfirmation(plan, inspection);
+    const width = parsePreviewWidth(options.width);
+    const preview = renderAuthoringPreview(plan, {
+      hash,
+      confirmationHash: confirmation,
+      width,
+      // Rendering itself contains no ANSI. Explicitly force the plain policy when NO_COLOR is
+      // set so a caller cannot accidentally enable colour through a shared option object later.
+      color: !process.env.NO_COLOR,
+      destination: inspection.directory,
+      destinationFingerprint: inspection.fingerprint,
+    });
+    const result = {
+      ok: true,
+      command: 'author preview',
+      // `hash` remains the copy-and-paste confirmation value for backwards-compatible CLI use.
+      // `planHash` is included separately for consumers that only need plan identity.
+      hash: confirmation,
+      planHash: hash,
+      confirmation,
+      canonicalJson: serializeAuthoringPlan(plan),
+      plan,
+      destination: { directory: inspection.directory, fingerprint: inspection.fingerprint },
+      preview,
+      noFilesWritten: true,
+    };
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+    process.stdout.write(preview);
+  });
+
+author
+  .command('write <planOrStdin>')
+  .description('Materialize content already supplied by a confirmed authoring plan.')
+  .requiredOption('--confirm <hash>', 'exact destination-bound SHA-256 from author preview')
+  .requiredOption('--output-dir <dir>', 'exact destination directory')
+  .option('--json', 'emit a machine-readable write result')
+  .action(async (planOrStdin: string, options: AuthorWriteCliOptions) => {
+    const plan = validateAuthoringPlan(await readAuthoringPlan(planOrStdin));
+    const planHash = hashAuthoringPlan(plan);
+    if (!options.outputDir) {
+      throw new Error('--output-dir is required');
+    }
+    const destination = authoringDestination(options.outputDir, plan.target.directory);
+    const inspection = await inspectAuthoringDestination(destination, plan);
+    const confirmation = hashAuthoringConfirmation(plan, inspection);
+    // Inspection is read-only. The write boundary receives the same snapshot and checks it again
+    // before creating a directory or establishing any new filesystem baseline.
+    if (options.confirm !== confirmation) {
+      throw new Error('authoring confirmation does not match the reviewed plan and destination; no files written');
+    }
+    const result = await writeAuthoringPlan(destination, plan, inspection);
+    const output = {
+      ok: true,
+      command: 'author write',
+      hash: confirmation,
+      planHash,
+      destination: { directory: result.directory, fingerprint: result.fingerprint },
+      written: result.written,
+      noFilesWritten: result.written.length === 0,
+    };
+    if (options.json) {
+      console.log(JSON.stringify(output, null, 2));
+      return;
+    }
+    console.log(`Plan SHA-256: ${planHash}`);
+    console.log(`Confirmation SHA-256: ${confirmation}`);
+    console.log(`Destination: ${result.directory}`);
+    console.log(`Destination fingerprint: ${result.fingerprint}`);
+    if (result.written.length === 0) {
+      console.log('No files written.');
+      return;
+    }
+    for (const file of result.written) {
+      console.log(`Wrote: ${file}`);
+    }
+  });
+
 async function main(): Promise<void> {
   try {
     rejectAssembleStylingOptions(process.argv);
@@ -338,6 +446,68 @@ async function readInputs(
   }
 
   return Promise.all(files.map(async (file) => ({ path: file, content: await readFile(file, 'utf8') })));
+}
+
+/** Read an authoring plan from exactly one safe relative regular file or stdin. */
+async function readAuthoringPlan(target: string): Promise<string> {
+  if (target === '-') {
+    return readStdin();
+  }
+  if (!isSafePlanPath(target)) {
+    throw new Error(`authoring plan path must be a safe relative path: ${JSON.stringify(target)}`);
+  }
+  let current = path.resolve(process.cwd());
+  const segments = target.split('/');
+  for (const [index, segment] of segments.entries()) {
+    current = path.join(current, segment);
+    const stats = await lstat(current);
+    if (stats.isSymbolicLink()) {
+      throw new Error(`authoring plan path must not contain a symbolic link: ${target}`);
+    }
+    if (index < segments.length - 1 && !stats.isDirectory()) {
+      throw new Error(`authoring plan path has a non-directory parent: ${target}`);
+    }
+    if (index === segments.length - 1 && !stats.isFile()) {
+      throw new Error(`authoring plan path is not a regular file: ${target}`);
+    }
+  }
+  return readFile(current, 'utf8');
+}
+
+function isSafePlanPath(value: string): boolean {
+  if (
+    !value ||
+    value.includes('\0') ||
+    value.includes('\\') ||
+    path.posix.isAbsolute(value) ||
+    path.win32.isAbsolute(value) ||
+    /^[A-Za-z]:/.test(value)
+  ) {
+    return false;
+  }
+  return value.split('/').every((segment) => segment.length > 0 && segment !== '.' && segment !== '..');
+}
+
+function authoringDestination(outputDirectory: string | undefined, packageDirectory: string | undefined): string {
+  // `--output-dir` names the exact package destination, so the directory printed by preview can
+  // be passed unchanged to write. A plan directory is only the preview default when no explicit
+  // destination was selected.
+  if (outputDirectory !== undefined) {
+    return path.resolve(outputDirectory);
+  }
+  return packageDirectory && packageDirectory !== '.'
+    ? path.resolve(process.cwd(), ...packageDirectory.split('/'))
+    : path.resolve(process.cwd());
+}
+
+function parsePreviewWidth(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!/^[0-9]+$/.test(value) || Number(value) < 1) {
+    throw new Error('--width must be a positive integer');
+  }
+  return Number(value);
 }
 
 function rejectAssembleStylingOptions(argv: string[]): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,44 @@ export { validate } from './gate/validate.js';
 export { convert } from './convert/assemble.js';
 export { assemble, extractIntent, realize } from './intent/index.js';
 export { collectSiteContext } from './context/run.js';
+export {
+  AUTHORING_PLAN_VERSION,
+  AuthoringPlanValidationError,
+  canonicalAuthoringPlanHash,
+  canonicalAuthoringPlanJson,
+  canonicalizeAuthoringPlan,
+  hashAuthoringPlan,
+  isSafeAuthoringRelativePath,
+  serializeAuthoringPlan,
+  validateAuthoringPlan,
+} from './authoring/schema.js';
+export { previewAuthoringPlan, renderAuthoringPreview } from './authoring/preview.js';
+export { hashAuthoringConfirmation, inspectAuthoringDestination, writeAuthoringPlan } from './authoring/destination.js';
 export type { SiteContextOptions } from './context/run.js';
+export type {
+  AuthoringAsset,
+  AuthoringAssetStatus,
+  AuthoringField,
+  AuthoringFieldMode,
+  AuthoringFile,
+  AuthoringFileOperation,
+  AuthoringLocking,
+  AuthoringLockMode,
+  AuthoringNodeLock,
+  AuthoringPattern,
+  AuthoringPatternOverride,
+  AuthoringPlan,
+  AuthoringStructureNode,
+  AuthoringStyleOutcome,
+  AuthoringStyleOutcomeKind,
+  AuthoringStyleStrategy,
+  AuthoringStyles,
+  AuthoringTarget,
+  JsonPrimitive,
+  JsonValue,
+} from './authoring/schema.js';
+export type { AuthoringPreviewContext, AuthoringPreviewOptions } from './authoring/preview.js';
+export type { AuthoringDestinationApproval, DestinationEntry, DestinationInspection } from './authoring/destination.js';
 export type {
   AssembleOptions,
   BlockRunnerConfig,

--- a/test/authoring.cli.test.ts
+++ b/test/authoring.cli.test.ts
@@ -1,0 +1,115 @@
+import { spawn } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { hashAuthoringPlan } from '../src/authoring/schema.js';
+
+const tsxImport = import.meta.resolve('tsx');
+
+function plan(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    version: 1,
+    generatorVersion: '0.9.0-preview.1',
+    target: { name: 'example/notice', title: 'Notice' },
+    structure: [],
+    fields: [],
+    locking: { mode: 'none' },
+    styles: { strategy: 'native', outcomes: [] },
+    pattern: { ready: false, overrides: [] },
+    assets: [],
+    files: [{ path: 'block.json', content: '{"apiVersion":3}\n', operation: 'create' }],
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe('author CLI', () => {
+  it('previews without writing and only writes the exact confirmed canonical plan', async () => {
+    const project = await mkdtemp(path.join(tmpdir(), 'block-runner-author-cli-'));
+    const input = plan();
+    await writeFile(path.join(project, 'plan.json'), JSON.stringify(input));
+
+    const preview = await runCli(['author', 'preview', 'plan.json', '--output-dir', 'generated', '--width', '62', '--json'], project);
+    expect(preview.code).toBe(0);
+    const previewJson = JSON.parse(preview.stdout) as { hash: string; preview: string; noFilesWritten: boolean };
+    expect(previewJson.noFilesWritten).toBe(true);
+    expect(previewJson.preview).toContain('No files written.');
+    expect(preview.stdout).not.toMatch(/\x1b\[/);
+    await expect(stat(path.join(project, 'generated'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+    const wrong = await runCli(
+      ['author', 'write', 'plan.json', '--confirm', '0'.repeat(64), '--output-dir', 'generated', '--json'],
+      project,
+    );
+    expect(wrong.code).toBe(2);
+    await expect(stat(path.join(project, 'generated'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+    const otherDestination = await runCli(
+      ['author', 'write', 'plan.json', '--confirm', previewJson.hash, '--output-dir', 'elsewhere', '--json'],
+      project,
+    );
+    expect(otherDestination.code).toBe(2);
+    await expect(stat(path.join(project, 'elsewhere'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+    const written = await runCli(
+      ['author', 'write', 'plan.json', '--confirm', previewJson.hash, '--output-dir', 'generated', '--json'],
+      project,
+    );
+    expect(written.code).toBe(0);
+    expect(JSON.parse(written.stdout)).toMatchObject({ written: ['block.json'], noFilesWritten: false });
+    expect(await readFile(path.join(project, 'generated', 'block.json'), 'utf8')).toBe('{"apiVersion":3}\n');
+  });
+
+  it('rejects approval when the previewed destination fingerprint has changed', async () => {
+    const project = await mkdtemp(path.join(tmpdir(), 'block-runner-author-cli-'));
+    const destination = path.join(project, 'generated');
+    await mkdir(destination);
+    await writeFile(path.join(destination, 'block.json'), 'before\n');
+    await writeFile(path.join(project, 'plan.json'), JSON.stringify(plan({
+      files: [{ path: 'block.json', content: 'replacement\n', operation: 'replace' }],
+    })));
+
+    const preview = await runCli(['author', 'preview', 'plan.json', '--output-dir', 'generated', '--json'], project);
+    expect(preview.code).toBe(0);
+    const previewJson = JSON.parse(preview.stdout) as { hash: string };
+    await writeFile(path.join(destination, 'block.json'), 'changed after preview\n');
+
+    const result = await runCli(
+      ['author', 'write', 'plan.json', '--confirm', previewJson.hash, '--output-dir', 'generated', '--json'],
+      project,
+    );
+    expect(result.code).toBe(2);
+    expect(await readFile(path.join(destination, 'block.json'), 'utf8')).toBe('changed after preview\n');
+  });
+
+  it('does not write when a canonical material decision changed after preview', async () => {
+    const project = await mkdtemp(path.join(tmpdir(), 'block-runner-author-cli-'));
+    const original = plan();
+    await writeFile(path.join(project, 'plan.json'), JSON.stringify(original));
+    const hash = hashAuthoringPlan(original);
+    await writeFile(path.join(project, 'plan.json'), JSON.stringify(plan({ warnings: ['changed'] })));
+
+    const result = await runCli(['author', 'write', 'plan.json', '--confirm', hash, '--output-dir', 'generated'], project);
+    expect(result.code).toBe(2);
+    await expect(stat(path.join(project, 'generated'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});
+
+function runCli(args: string[], cwd: string): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--import', tsxImport, new URL('../src/cli.ts', import.meta.url).pathname, ...args], {
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+    child.stdin.end();
+  });
+}

--- a/test/authoring.destination.test.ts
+++ b/test/authoring.destination.test.ts
@@ -1,0 +1,90 @@
+import { mkdtemp, mkdir, readFile, stat, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { inspectAuthoringDestination, writeAuthoringPlan } from '../src/authoring/destination.js';
+import { validateAuthoringPlan } from '../src/authoring/schema.js';
+
+function plan(files: unknown[]) {
+  return validateAuthoringPlan({
+    version: 1,
+    generatorVersion: '0.9.0-preview.1',
+    target: { name: 'example/notice', title: 'Notice' },
+    structure: [],
+    fields: [],
+    locking: { mode: 'none' },
+    styles: { strategy: 'native', outcomes: [] },
+    pattern: { ready: false, overrides: [] },
+    assets: [],
+    files,
+    warnings: [],
+  });
+}
+
+describe('authoring destination', () => {
+  it('fingerprints a destination without creating it', async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), 'block-runner-author-'));
+    const destination = path.join(parent, 'does-not-exist');
+    const inspection = await inspectAuthoringDestination(destination, plan([{ path: 'block.json' }]));
+
+    expect(inspection.fingerprint).toMatch(/^sha256:[a-f0-9]{64}$/);
+    await expect(stat(destination)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('refuses a collision without changing the existing file', async () => {
+    const destination = await mkdtemp(path.join(tmpdir(), 'block-runner-author-'));
+    const existing = path.join(destination, 'block.json');
+    await writeFile(existing, 'original\n');
+
+    await expect(writeAuthoringPlan(destination, plan([{ path: 'block.json', content: 'new\n' }]))).rejects.toThrow(/already exists/);
+    expect(await readFile(existing, 'utf8')).toBe('original\n');
+  });
+
+  it('requires an explicit hash-bound replacement operation and publishes supplied content', async () => {
+    const destination = await mkdtemp(path.join(tmpdir(), 'block-runner-author-'));
+    const existing = path.join(destination, 'block.json');
+    await writeFile(existing, 'original\n');
+
+    const result = await writeAuthoringPlan(
+      destination,
+      plan([{ path: 'block.json', content: 'replacement\n', operation: 'replace' }]),
+    );
+
+    expect(result.written).toEqual(['block.json']);
+    expect(await readFile(existing, 'utf8')).toBe('replacement\n');
+  });
+
+  it('rejects a changed reviewed destination before establishing a write baseline', async () => {
+    const destination = await mkdtemp(path.join(tmpdir(), 'block-runner-author-'));
+    const existing = path.join(destination, 'block.json');
+    const reviewedPlan = plan([{ path: 'block.json', content: 'replacement\n', operation: 'replace' }]);
+    await writeFile(existing, 'before\n');
+    const approval = await inspectAuthoringDestination(destination, reviewedPlan);
+    await writeFile(existing, 'changed after preview\n');
+
+    await expect(writeAuthoringPlan(destination, reviewedPlan, approval)).rejects.toThrow(/no longer matches the reviewed preview/);
+    expect(await readFile(existing, 'utf8')).toBe('changed after preview\n');
+  });
+
+  it('rejects a symlink in a planned output path before writing', async () => {
+    const destination = await mkdtemp(path.join(tmpdir(), 'block-runner-author-'));
+    const outside = await mkdtemp(path.join(tmpdir(), 'block-runner-author-outside-'));
+    await symlink(outside, path.join(destination, 'src'));
+    await mkdir(path.join(outside, 'nested'));
+
+    await expect(writeAuthoringPlan(destination, plan([{ path: 'src/edit.ts', content: 'export {};\n' }]))).rejects.toThrow(/symbolic-link/);
+    await expect(stat(path.join(outside, 'edit.ts'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('rejects a symlink in the destination prefix before it can be followed', async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), 'block-runner-author-'));
+    const outside = await mkdtemp(path.join(tmpdir(), 'block-runner-author-outside-'));
+    const redirected = path.join(parent, 'redirected');
+    const destination = path.join(redirected, 'generated');
+    await symlink(outside, redirected);
+
+    await expect(inspectAuthoringDestination(destination, plan([{ path: 'block.json' }]))).rejects.toThrow(/symbolic-link/);
+    await expect(writeAuthoringPlan(destination, plan([{ path: 'block.json', content: 'new\n' }]))).rejects.toThrow(/symbolic-link/);
+    await expect(stat(path.join(outside, 'generated'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/test/authoring.preview.test.ts
+++ b/test/authoring.preview.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { renderAuthoringPreview } from '../src/authoring/preview.js';
+import { validateAuthoringPlan } from '../src/authoring/schema.js';
+
+const plan = validateAuthoringPlan({
+  version: 1,
+  generatorVersion: '0.9.0-preview.1',
+  target: {
+    name: 'example/feature-grid',
+    title: 'Feature grid',
+    directory: 'blocks/feature-grid',
+    description: 'A reusable feature grid.',
+    category: 'design',
+    textDomain: 'example',
+    wordpress: '6.8',
+  },
+  structure: [
+    {
+      id: 'root',
+      block: 'core/group',
+      label: 'Feature grid',
+      attributes: { layout: { type: 'constrained' } },
+      lock: { move: false, remove: false },
+      children: [{ id: 'heading', block: 'core/heading', label: 'Heading' }],
+    },
+  ],
+  fields: [
+    { id: 'heading', label: 'Heading', mode: 'editable', type: 'rich-text', node: 'heading', attribute: 'content' },
+    { id: 'layout', label: 'Layout', mode: 'fixed', type: 'layout' },
+    { id: 'accent', label: 'Accent', mode: 'override', type: 'color' },
+  ],
+  locking: { mode: 'contentOnly', move: false, remove: false, insert: false },
+  styles: {
+    strategy: 'mixed',
+    outcomes: [
+      { property: 'color', outcome: 'token', token: 'accent' },
+      { property: 'display', outcome: 'scoped-css', value: 'grid', reason: 'No native support.' },
+    ],
+  },
+  pattern: { ready: true, overrides: [{ field: 'accent', label: 'Accent' }] },
+  assets: [{ id: 'logo', source: 'assets/logo.svg', kind: 'svg', destination: 'assets/logo.svg', status: 'ready', required: true }],
+  files: [
+    { path: 'block.json', kind: 'metadata', operation: 'create' },
+    { path: 'src/edit.tsx', kind: 'editor', operation: 'replace' },
+  ],
+  warnings: ['The source logo needs a final license check.'],
+});
+
+describe('authoring preview', () => {
+  it('renders the complete plan deterministically without ANSI sequences', () => {
+    const first = renderAuthoringPreview(plan, { width: 80 });
+    const second = renderAuthoringPreview(plan, { width: 80, color: true });
+
+    expect(first).toBe(second);
+    expect(first).toContain('Authoring plan preview');
+    expect(first).toContain('Target');
+    expect(first).toContain('Structure');
+    expect(first).toContain('attributes:');
+    expect(first).toContain('  `- core/heading');
+    expect(first).toContain('Editable fields');
+    expect(first).toContain('[fixed] Layout');
+    expect(first).toContain('[editable] Heading');
+    expect(first).toContain('[override] Accent');
+    expect(first).toContain('Style outcomes');
+    expect(first).toContain('Assets');
+    expect(first).toContain('Pattern readiness');
+    expect(first).toContain('Planned files');
+    expect(first).toContain('Warnings');
+    expect(first).toContain('No files written.');
+    expect(first).toMatch(/Plan SHA-256: [a-f0-9]{64}/);
+    expect(first).not.toContain('Confirmation SHA-256:');
+    expect(first).not.toMatch(/\x1b\[/);
+  });
+
+  it('wraps to the supplied terminal width', () => {
+    for (const width of [44, 12]) {
+      const output = renderAuthoringPreview(plan, { width });
+      expect(output.split('\n').every((line) => line.length <= width)).toBe(true);
+    }
+  });
+});

--- a/test/authoring.schema.test.ts
+++ b/test/authoring.schema.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { hashAuthoringPlan, serializeAuthoringPlan, validateAuthoringPlan } from '../src/authoring/schema.js';
+
+function plan(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    version: 1,
+    generatorVersion: '0.9.0-preview.1',
+    target: { name: 'example/notice', title: 'Notice' },
+    structure: [{ block: 'core/group', id: 'root' }],
+    fields: [{ id: 'message', label: 'Message', mode: 'editable' }],
+    locking: { mode: 'contentOnly', move: false },
+    styles: { strategy: 'native', outcomes: [{ property: 'color', outcome: 'token', token: 'primary' }] },
+    pattern: { ready: true, overrides: [{ field: 'message' }] },
+    assets: [],
+    files: [{ path: 'block.json', operation: 'create' }],
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe('AuthoringPlan schema', () => {
+  it('canonicalizes object key order and binds every material field into the hash', () => {
+    const first = plan();
+    const reordered = {
+      warnings: [],
+      files: [{ operation: 'create', path: 'block.json' }],
+      assets: [],
+      pattern: { overrides: [{ field: 'message' }], ready: true },
+      styles: { outcomes: [{ token: 'primary', outcome: 'token', property: 'color' }], strategy: 'native' },
+      locking: { move: false, mode: 'contentOnly' },
+      fields: [{ mode: 'editable', label: 'Message', id: 'message' }],
+      structure: [{ id: 'root', block: 'core/group' }],
+      target: { title: 'Notice', name: 'example/notice' },
+      generatorVersion: '0.9.0-preview.1',
+      version: 1,
+    };
+
+    expect(serializeAuthoringPlan(first)).toBe(serializeAuthoringPlan(reordered));
+    expect(hashAuthoringPlan(first)).toBe(hashAuthoringPlan(reordered));
+    expect(hashAuthoringPlan(plan({ warnings: ['review this'] }))).not.toBe(hashAuthoringPlan(first));
+    expect(hashAuthoringPlan(plan({ generatorVersion: '0.9.0-preview.2' }))).not.toBe(hashAuthoringPlan(first));
+  });
+
+  it('rejects traversal, absolute, drive-relative, and conflicting planned paths', () => {
+    for (const file of ['../escape.ts', '/tmp/escape.ts', 'C:\\escape.ts', 'C:escape.ts', 'src/../escape.ts', 'src\\escape.ts']) {
+      expect(() => validateAuthoringPlan(plan({ files: [{ path: file }] }))).toThrow(/safe relative path/);
+    }
+    expect(() => validateAuthoringPlan(plan({ files: [{ path: 'src' }, { path: 'src/edit.ts' }] }))).toThrow(/descendant/);
+  });
+});


### PR DESCRIPTION
## Problem

Registered-block authoring needs decisions that HTML cannot supply: block identity, native child structure, editable fields, locking, styles, assets and destination files. Writing source before those decisions are confirmed lets the plan drift from what Block Runner emits. Closes #2.

## Solution

Add a versioned `AuthoringPlan`, deterministic canonicalisation and a read-only terminal preview. The write step is bound to the exact plan hash, destination snapshot, paths and symlink state shown in that preview. Preview never writes files, and replacement of existing files is a separate decision.

## Testing and verification

Focused tests cover canonical hashes, terminal-width output, wrong or stale confirmation, unsafe paths, collisions and symlink escapes. The current repository verification is recorded in the [green CI run](https://github.com/humanmade/block-runner/actions/runs/33879578421) on Node 20, 22 and 24 with WordPress 7.1.

## Risk and rollout

The core remains deterministic and non-interactive. The calling harness owns interpretation and confirmation; Block Runner does not bundle a model or an API key.
