### PR TITLE
Support existing wp-scripts plugins and standalone plugin output

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Gutenberg before it reaches the editor.
 | `fix` | Canonicalize near-miss block markup. |
 | `context` | Read a WordPress site into a `site.context.json` manifest (read-only). |
 | `skill` | Print or install the agent guide. |
+| `plugin inspect` | Read-only detection of the supported `@wordpress/scripts` plugin profile. |
+| `plugin preview` / `plugin write` | Preview, confirm, and integrate a generated registered-block directory; or create a standalone plugin wrapper. |
 
 ```sh
 block-runner convert hero.html                    # blocks to stdout
@@ -170,7 +172,22 @@ block-runner author hero.html --name acme/hero --out-dir blocks/hero
 block-runner assemble intent.json                 # structure in, blocks out
 block-runner validate "content/**/*.html" --json
 block-runner fix post-content.html --out post-content.fixed.html
+
+# Inspect a host before integrating generated block files. This writes nothing.
+block-runner plugin inspect ./my-plugin --json
+
+# Preview every exact target, then use the displayed fingerprint with `plugin write`.
+block-runner plugin preview ./generated-block --host ./my-plugin
+
+# For an absent or unsupported host layout, make a complete standalone plugin instead.
+block-runner plugin preview ./generated-block --standalone ./my-notice-plugin
 ```
+
+`plugin preview` never writes. Its fingerprint binds the exact target files; pass it to
+`plugin write --confirm <fingerprint>`. Existing PHP or `package.json` files are marked as
+separate replacement approvals, so their absolute preview paths must also be supplied with
+`--approve-replace <path...>` before they can change. An unrecognised host is refused without
+writing and the command offers the standalone form above.
 
 ### Registered-block authoring
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6874,6 +6874,24 @@
         "node": ">= 12"
       }
     },
+    "node_modules/tsup/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.23.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
@@ -7245,6 +7263,24 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { createRequire } from 'node:module';
 import { existsSync } from 'node:fs';
-import { lstat, readFile, writeFile } from 'node:fs/promises';
+import { lstat, readFile, readdir, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
@@ -15,6 +15,14 @@ import { realize } from './intent/index.js';
 import { loadConfig } from './config/load.js';
 import { collectSiteContext } from './context/run.js';
 import { installCanonicalSkill, readCanonicalSkillGuide, SkillScope, SkillTarget } from './skill.js';
+import {
+  detectWpScriptsPlugin,
+  planExistingPluginOutput,
+  planStandalonePluginOutput,
+  UnsupportedPluginLayoutError,
+  writePluginOutput,
+  type GeneratedBlockPackage,
+} from './plugin/profile.js';
 import { BlockRunnerReport, CommonOptions, HeadlessBootError } from './types.js';
 import { hashAuthoringConfirmation, inspectAuthoringDestination, writeAuthoringPlan } from './authoring/destination.js';
 import { hashAuthoringPlan, serializeAuthoringPlan, validateAuthoringPlan } from './authoring/schema.js';
@@ -64,6 +72,21 @@ interface AuthorWriteCliOptions {
   confirm?: string;
   outputDir?: string;
   json?: boolean;
+}
+
+interface PluginInspectCliOptions {
+  json?: boolean;
+}
+
+interface PluginPreviewCliOptions {
+  host?: string;
+  standalone?: string;
+  json?: boolean;
+}
+
+interface PluginWriteCliOptions extends PluginPreviewCliOptions {
+  confirm?: string;
+  approveReplace?: string[];
 }
 
 const program = new Command();
@@ -272,6 +295,70 @@ program
     if (!manifest.endsWith('\n')) {
       process.stdout.write('\n');
     }
+  });
+
+const plugin = program
+  .command('plugin')
+  .description('Inspect or package a generated registered block for a supported wp-scripts plugin.');
+
+plugin
+  .command('inspect <hostDirectory>')
+  .description('Report a read-only @wordpress/scripts host profile and its registration strategy.')
+  .option('--json', 'emit a machine-readable profile')
+  .action(async (hostDirectory: string, options: PluginInspectCliOptions) => {
+    const profile = await detectWpScriptsPlugin(hostDirectory);
+    if (options.json) {
+      console.log(JSON.stringify(profile, null, 2));
+      process.exitCode = profile.kind === 'recognized' ? 0 : 1;
+      return;
+    }
+    if (profile.kind !== 'recognized') {
+      console.error(`plugin inspect: ${profile.reason}`);
+      console.error('No files written. Use plugin preview <block-dir> --standalone <output-dir> to create a standalone plugin.');
+      process.exitCode = 1;
+      return;
+    }
+    console.log([
+      'plugin inspect: recognised',
+      `@wordpress/scripts=${profile.wpScriptsVersion}`,
+      `source root=${profile.sourceRoot}`,
+      `build root=${profile.buildRoot}`,
+      `entry discovery=${profile.entryDiscovery}`,
+      `registration=${profile.registration} (${profile.registrationFile})`,
+    ].join('\n'));
+  });
+
+plugin
+  .command('preview <blockDirectory>')
+  .description('List every generated and bootstrap file that would be touched; writes nothing.')
+  .option('--host <directory>', 'recognised existing wp-scripts plugin root')
+  .option('--standalone <directory>', 'plan a complete standalone plugin wrapper instead')
+  .option('--json', 'emit the machine-readable plan')
+  .action(async (blockDirectory: string, options: PluginPreviewCliOptions) => {
+    const plan = await pluginPlanForCli(blockDirectory, options);
+    emitPluginPlan(plan, options.json ?? false);
+  });
+
+plugin
+  .command('write <blockDirectory>')
+  .description('Write exactly a previewed plugin plan after its fingerprint and replacement approvals are supplied.')
+  .requiredOption('--confirm <fingerprint>', 'exact fingerprint printed by plugin preview')
+  .option('--host <directory>', 'recognised existing wp-scripts plugin root')
+  .option('--standalone <directory>', 'write a complete standalone plugin wrapper instead')
+  .option('--approve-replace <path...>', 'absolute preview paths explicitly approved for replacement')
+  .option('--json', 'emit a machine-readable write result')
+  .action(async (blockDirectory: string, options: PluginWriteCliOptions) => {
+    const plan = await pluginPlanForCli(blockDirectory, options);
+    if (options.confirm !== plan.fingerprint) {
+      throw new Error('plugin confirmation does not match the reviewed preview; no files written');
+    }
+    const result = await writePluginOutput(plan, { authorizedReplacements: options.approveReplace });
+    if (options.json) {
+      console.log(JSON.stringify({ ok: true, ...result }, null, 2));
+      return;
+    }
+    console.log(`plugin write: ${result.written.length} file${result.written.length === 1 ? '' : 's'} written to ${result.directory}`);
+    for (const file of result.written) console.log(`- ${file}`);
   });
 
 program
@@ -689,6 +776,79 @@ function ensureSafeOutputTarget(
 
 function looksLikeInlineHtml(value: string): boolean {
   return /<([a-z][\w:-]*)(\s|>|\/>)/i.test(value) || /<!--\s+wp:/.test(value);
+}
+
+async function pluginPlanForCli(
+  blockDirectory: string,
+  options: Pick<PluginPreviewCliOptions, 'host' | 'standalone'>,
+) {
+  if (Boolean(options.host) === Boolean(options.standalone)) {
+    throw new Error('Pass exactly one of --host <plugin-root> or --standalone <output-dir>.');
+  }
+  const generated = await readGeneratedBlockPackage(blockDirectory);
+  if (options.standalone) {
+    return planStandalonePluginOutput(options.standalone, generated);
+  }
+  try {
+    return await planExistingPluginOutput(options.host!, generated);
+  } catch (error) {
+    if (error instanceof UnsupportedPluginLayoutError) {
+      throw new Error(`${error.message} Offer: plugin preview ${JSON.stringify(blockDirectory)} --standalone <output-dir>.`);
+    }
+    throw error;
+  }
+}
+
+function emitPluginPlan(
+  plan: Awaited<ReturnType<typeof pluginPlanForCli>>,
+  json = false,
+): void {
+  if (json) {
+    console.log(JSON.stringify({ ok: true, ...plan, noFilesWritten: true }, null, 2));
+    return;
+  }
+  console.log(`plugin preview: ${plan.mode}`);
+  console.log(`target directory: ${plan.targetDirectory}`);
+  console.log(`confirmation: ${plan.fingerprint}`);
+  for (const note of plan.notes) console.log(`- ${note}`);
+  console.log('touched files:');
+  for (const file of plan.touchedFiles) {
+    console.log(`- ${file.operation}${file.requiresSeparateAuthorization ? ' (separate authorization required)' : ''}: ${file.path}`);
+  }
+  console.log('No files written.');
+}
+
+async function readGeneratedBlockPackage(directory: string): Promise<GeneratedBlockPackage> {
+  const root = path.resolve(directory);
+  const metadataFile = path.join(root, 'block.json');
+  if (!existsSync(metadataFile)) {
+    throw new Error(`Generated block directory must contain block.json: ${root}`);
+  }
+  const files: Record<string, Buffer> = {};
+  async function walk(current: string, prefix = ''): Promise<void> {
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) {
+        throw new Error(`Generated block directory must not contain symbolic links: ${path.join(current, entry.name)}`);
+      }
+      if (entry.name === 'node_modules' || entry.name === '.git') continue;
+      const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+      const absolute = path.join(current, entry.name);
+      if (entry.isDirectory()) await walk(absolute, relative);
+      else if (entry.isFile()) files[relative] = await readFile(absolute);
+    }
+  }
+  await walk(root);
+  let metadata: { name?: unknown };
+  try {
+    metadata = JSON.parse(files['block.json']!.toString('utf8')) as { name?: unknown };
+  } catch {
+    throw new Error(`Generated block metadata is not valid JSON: ${metadataFile}`);
+  }
+  if (typeof metadata.name !== 'string') {
+    throw new Error(`Generated block metadata has no name: ${metadataFile}`);
+  }
+  return { name: metadata.name, files };
 }
 
 await main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,30 @@ export {
 } from './authoring/schema.js';
 export { previewAuthoringPlan, renderAuthoringPreview } from './authoring/preview.js';
 export { hashAuthoringConfirmation, inspectAuthoringDestination, writeAuthoringPlan } from './authoring/destination.js';
+export {
+  assertStandaloneZipEntries,
+  detectWpScriptsPlugin,
+  planExistingPluginOutput,
+  planStandalonePluginOutput,
+  STANDALONE_WP_SCRIPTS_VERSION,
+  UnsupportedPluginLayoutError,
+  WP_SCRIPTS_PROFILE,
+  writePluginOutput,
+} from './plugin/profile.js';
+export type {
+  GeneratedBlockPackage as PluginGeneratedBlockPackage,
+  PluginFileContent,
+  PluginFileOperation,
+  PluginOutputPlan,
+  PluginPlanMode,
+  PluginProfile,
+  PluginRegistrationStrategy,
+  PluginTouchedFile,
+  UnsupportedPluginProfile,
+  WpScriptsPluginProfile,
+  WritePluginOutputOptions,
+  WritePluginOutputResult,
+} from './plugin/profile.js';
 export type { SiteContextOptions } from './context/run.js';
 export type {
   AuthoringAsset,

--- a/src/plugin/profile.ts
+++ b/src/plugin/profile.ts
@@ -158,11 +158,16 @@ export async function detectWpScriptsPlugin(rootDirectory: string): Promise<Plug
 
   const scripts = asObjectOrEmpty(packageJson.scripts);
   const buildScript = typeof scripts.build === 'string' ? scripts.build : undefined;
-  if (!buildScript || !isWpScriptsBuild(buildScript)) {
+  if (!buildScript || /[;&|><`$]/.test(buildScript)) {
     return unsupported('unsupported', root, 'The package build script is not a direct wp-scripts build command.');
   }
-  if (/[;&|><`$]/.test(buildScript) || /--(?:webpack-config|webpack-src-dir|config)(?:=|\s)/.test(buildScript)) {
-    return unsupported('unsupported', root, 'A custom webpack/config build layout is outside the supported wp-scripts profile.');
+  const parsedBuild = parseWpScriptsBuild(buildScript);
+  if (!parsedBuild) {
+    return unsupported(
+      'unsupported',
+      root,
+      'The package build script must be a direct wp-scripts build command with no positional entries and only supported profile flags.',
+    );
   }
   const automaticWebpackConfig = await findAutomaticWebpackConfig(root);
   if (automaticWebpackConfig) {
@@ -173,8 +178,8 @@ export async function detectWpScriptsPlugin(rootDirectory: string): Promise<Plug
     );
   }
 
-  const sourceRoot = commandPath(buildScript, 'source-path') ?? 'src';
-  const buildRoot = commandPath(buildScript, 'output-path') ?? 'build';
+  const sourceRoot = parsedBuild.sourcePath ?? 'src';
+  const buildRoot = parsedBuild.outputPath ?? 'build';
   if (!isSafeRelativeDirectory(sourceRoot) || !isSafeRelativeDirectory(buildRoot)) {
     return unsupported('unsupported', root, 'The wp-scripts source or output path is not a safe relative directory.');
   }
@@ -518,13 +523,89 @@ function asObjectOrEmpty(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }
 
-function isWpScriptsBuild(command: string): boolean {
-  return /^\s*wp-scripts\s+build(?:\s|$)/.test(command);
+interface ParsedWpScriptsBuild {
+  sourcePath?: string;
+  outputPath?: string;
+  blocksManifest: boolean;
 }
 
-function commandPath(command: string, option: 'source-path' | 'output-path'): string | undefined {
-  const match = command.match(new RegExp(`--${option}(?:=|\\s+)([^\\s]+)`));
-  return match?.[1]?.replace(/^['"]|['"]$/g, '');
+/**
+ * This profile relies on wp-scripts' metadata entry discovery, which is disabled when a build
+ * entry is supplied positionally. Parse the small, explicit command shape rather than merely
+ * matching its prefix so an arbitrary entry point cannot be mistaken for recursive discovery.
+ */
+function parseWpScriptsBuild(command: string): ParsedWpScriptsBuild | undefined {
+  const argv = shellWords(command);
+  if (!argv || argv[0] !== 'wp-scripts' || argv[1] !== 'build') return undefined;
+
+  const parsed: ParsedWpScriptsBuild = { blocksManifest: false };
+  for (let index = 2; index < argv.length; index += 1) {
+    const argument = argv[index]!;
+    if (argument === '--blocks-manifest') {
+      if (parsed.blocksManifest) return undefined;
+      parsed.blocksManifest = true;
+      continue;
+    }
+
+    const option = argument.match(/^--(source-path|output-path)(?:=(.*))?$/);
+    if (!option) return undefined;
+    const key = option[1] === 'source-path' ? 'sourcePath' : 'outputPath';
+    if (parsed[key] !== undefined) return undefined;
+
+    const value = option[2] === undefined ? argv[++index] : option[2];
+    if (!value || value.startsWith('--')) return undefined;
+    parsed[key] = value;
+  }
+  return parsed;
+}
+
+/** Split the limited package-script syntax we support, including quoted option values. */
+function shellWords(command: string): string[] | undefined {
+  const words: string[] = [];
+  let word = '';
+  let hasWord = false;
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  for (const character of command) {
+    if (escaped) {
+      word += character;
+      hasWord = true;
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      hasWord = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = undefined;
+      else word += character;
+      hasWord = true;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      hasWord = true;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      if (hasWord) words.push(word);
+      word = '';
+      hasWord = false;
+      continue;
+    }
+    word += character;
+    hasWord = true;
+  }
+  if (quote || escaped) return undefined;
+  if (hasWord) words.push(word);
+  return words;
+}
+
+function isWpScriptsBuild(command: string): boolean {
+  return parseWpScriptsBuild(command) !== undefined;
 }
 
 function isSafeRelativeDirectory(value: string): boolean {

--- a/src/plugin/profile.ts
+++ b/src/plugin/profile.ts
@@ -1,0 +1,935 @@
+import { execFile } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { chmod, lstat, mkdir, readFile, readdir, rename, unlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The single host profile this preview recognises.  Deliberately accepting only a small,
+ * explainable shape is safer than putting a source directory into an arbitrary webpack build.
+ */
+export const WP_SCRIPTS_PROFILE = 'wordpress-scripts-block-metadata-v1' as const;
+export const STANDALONE_WP_SCRIPTS_VERSION = '34.2.0' as const;
+
+export type PluginRegistrationStrategy = 'direct' | 'metadata-collection';
+export type PluginPlanMode = 'existing' | 'standalone';
+export type PluginFileOperation = 'create' | 'modify';
+export type PluginFileContent = string | Buffer;
+
+export interface GeneratedBlockPackage {
+  /** The block name stored in block.json, such as `acme/feature-grid`. */
+  name: string;
+  /** Files below the generated block directory. The keys must be safe POSIX relative paths. */
+  files: Readonly<Record<string, PluginFileContent>>;
+}
+
+export interface WpScriptsPluginProfile {
+  kind: 'recognized';
+  profile: typeof WP_SCRIPTS_PROFILE;
+  root: string;
+  wpScriptsVersion: string;
+  packageFile: string;
+  buildScript: string;
+  sourceRoot: string;
+  buildRoot: string;
+  entryDiscovery: string;
+  registration: PluginRegistrationStrategy;
+  registrationFile: string;
+  /** The source-relative directory in which a new block belongs. */
+  blockDirectory: string;
+  /** The build-relative directory produced for a new block. */
+  buildDirectory: string;
+  metadataCollection?: {
+    directory: string;
+    manifest: string;
+    /** The output-root-relative block directory used as the metadata collection key. */
+    key: string;
+  };
+}
+
+export interface UnsupportedPluginProfile {
+  kind: 'absent' | 'unsupported' | 'ambiguous';
+  root: string;
+  reason: string;
+  /** A caller can show this exact option without guessing whether fallback is safe. */
+  standaloneAvailable: true;
+}
+
+export type PluginProfile = WpScriptsPluginProfile | UnsupportedPluginProfile;
+
+export interface PluginTouchedFile {
+  /** Absolute file path. This is intentionally suitable for an approval UI. */
+  path: string;
+  relativePath: string;
+  operation: PluginFileOperation;
+  /** Raw bytes are retained so generated runtime assets are never text-decoded. */
+  content: Buffer;
+  /** Existing file content from the read-only inspection, never a hash-only blind write. */
+  previousContent?: Buffer;
+  requiresSeparateAuthorization: boolean;
+}
+
+export interface PluginOutputPlan {
+  mode: PluginPlanMode;
+  targetDirectory: string;
+  block: {
+    name: string;
+    directory: string;
+    buildDirectory: string;
+  };
+  profile?: WpScriptsPluginProfile;
+  touchedFiles: PluginTouchedFile[];
+  notes: string[];
+  /** Stable identity for a preview/confirmation layer. */
+  fingerprint: string;
+}
+
+export interface WritePluginOutputOptions {
+  /**
+   * Exact absolute paths from `touchedFiles` that a user separately approved for replacement.
+   * New files do not need this authority. Package and PHP bootstrap edits always do.
+   */
+  authorizedReplacements?: readonly string[];
+}
+
+export interface WritePluginOutputResult {
+  directory: string;
+  written: string[];
+  fingerprint: string;
+}
+
+export class UnsupportedPluginLayoutError extends Error {
+  readonly profile: UnsupportedPluginProfile;
+
+  constructor(profile: UnsupportedPluginProfile) {
+    super(`${profile.reason} No files were written. Generate a standalone plugin instead.`);
+    this.name = 'UnsupportedPluginLayoutError';
+    this.profile = profile;
+  }
+}
+
+/**
+ * Detect the one supported existing-plugin profile, without changing the filesystem.  The
+ * report includes the script version, source/build roots, discovery method, and registration
+ * strategy so an approval screen has facts rather than inferred destination paths.
+ */
+export async function detectWpScriptsPlugin(rootDirectory: string): Promise<PluginProfile> {
+  const root = path.resolve(rootDirectory);
+  const rootStats = await lstatMaybe(root);
+  if (rootStats?.isSymbolicLink()) {
+    return unsupported('unsupported', root, 'The requested host root is a symbolic link.');
+  }
+  const packageFile = path.join(root, 'package.json');
+  if (!existsSync(packageFile)) {
+    return unsupported('absent', root, 'No package.json was found at the requested host root.');
+  }
+  const packageStats = await lstatMaybe(packageFile);
+  if (!packageStats?.isFile() || packageStats.isSymbolicLink()) {
+    return unsupported('unsupported', root, 'The host package.json is not a regular file.');
+  }
+
+  let packageText: string;
+  let packageJson: Record<string, unknown>;
+  try {
+    packageText = await readFile(packageFile, 'utf8');
+    packageJson = asObject(JSON.parse(packageText), 'package.json must contain an object');
+  } catch (error) {
+    return unsupported(
+      'unsupported',
+      root,
+      `Could not read a valid package.json (${error instanceof Error ? error.message : String(error)}).`,
+    );
+  }
+
+  const dependencies = { ...asObjectOrEmpty(packageJson.dependencies), ...asObjectOrEmpty(packageJson.devDependencies) };
+  const wpScriptsVersion = typeof dependencies['@wordpress/scripts'] === 'string'
+    ? dependencies['@wordpress/scripts']
+    : undefined;
+  if (wpScriptsVersion !== STANDALONE_WP_SCRIPTS_VERSION) {
+    return unsupported(
+      'unsupported',
+      root,
+      `This package must declare @wordpress/scripts exactly at ${STANDALONE_WP_SCRIPTS_VERSION}.`,
+    );
+  }
+
+  const scripts = asObjectOrEmpty(packageJson.scripts);
+  const buildScript = typeof scripts.build === 'string' ? scripts.build : undefined;
+  if (!buildScript || !isWpScriptsBuild(buildScript)) {
+    return unsupported('unsupported', root, 'The package build script is not a direct wp-scripts build command.');
+  }
+  if (/[;&|><`$]/.test(buildScript) || /--(?:webpack-config|webpack-src-dir|config)(?:=|\s)/.test(buildScript)) {
+    return unsupported('unsupported', root, 'A custom webpack/config build layout is outside the supported wp-scripts profile.');
+  }
+  const automaticWebpackConfig = await findAutomaticWebpackConfig(root);
+  if (automaticWebpackConfig) {
+    return unsupported(
+      'unsupported',
+      root,
+      `The automatically loaded webpack configuration ${automaticWebpackConfig} is outside the supported wp-scripts profile.`,
+    );
+  }
+
+  const sourceRoot = commandPath(buildScript, 'source-path') ?? 'src';
+  const buildRoot = commandPath(buildScript, 'output-path') ?? 'build';
+  if (!isSafeRelativeDirectory(sourceRoot) || !isSafeRelativeDirectory(buildRoot)) {
+    return unsupported('unsupported', root, 'The wp-scripts source or output path is not a safe relative directory.');
+  }
+  const sourceDirectory = path.join(root, sourceRoot);
+  const sourceStats = await lstatMaybe(sourceDirectory);
+  if (!sourceStats?.isDirectory() || sourceStats.isSymbolicLink()) {
+    return unsupported('unsupported', root, `The declared source root ${JSON.stringify(sourceRoot)} is not a regular directory.`);
+  }
+
+  const blockMetadata = await findBlockMetadata(sourceDirectory);
+  if (blockMetadata.length === 0) {
+    return unsupported(
+      'unsupported',
+      root,
+      `No block.json file was found below the declared wp-scripts source root ${JSON.stringify(sourceRoot)}.`,
+    );
+  }
+  const blockDirectories = new Set(blockMetadata.map((file) => path.posix.dirname(file)));
+  if (blockDirectories.size !== blockMetadata.length) {
+    return unsupported('ambiguous', root, 'More than one block.json was found in a source directory.');
+  }
+  // A source root can contain a block namespace folder (for example `src/blocks/foo`). Preserve
+  // that entry layout by placing the new sibling below the common parent of detected entries.
+  const entryParent = commonDirectory([...blockDirectories].map((directory) => path.posix.dirname(directory)));
+  const blockDirectory = joinPosix(sourceRoot, entryParent);
+  const buildDirectory = joinPosix(buildRoot, entryParent);
+
+  const phpFiles = await findPhpFiles(root);
+  const direct = await findDirectRegistration(root, phpFiles, buildRoot);
+  const collection = await findCollectionRegistration(root, phpFiles, buildRoot);
+  if (direct && collection) {
+    return unsupported('ambiguous', root, 'Both direct registration and metadata-collection registration were found.');
+  }
+  if (!direct && !collection) {
+    return unsupported(
+      'unsupported',
+      root,
+      `No supported PHP registration bootstrap was found for the ${JSON.stringify(buildRoot)} build root.`,
+    );
+  }
+
+  const registration = direct ? 'direct' : 'metadata-collection';
+  const registrationFile = direct?.file ?? collection!.file;
+  return {
+    kind: 'recognized',
+    profile: WP_SCRIPTS_PROFILE,
+    root,
+    wpScriptsVersion,
+    packageFile,
+    buildScript,
+    sourceRoot,
+    buildRoot,
+    entryDiscovery: `wp-scripts scans block.json recursively below ${sourceRoot}; each metadata directory is an entry (new entries belong below ${blockDirectory}).`,
+    registration,
+    registrationFile,
+    // WordPress scripts maps a source metadata path `blocks/example/block.json` to the same path
+    // below its output root. Keep this an explicit profile fact, not a string guess at write time.
+    blockDirectory,
+    buildDirectory,
+    ...(collection
+      ? {
+          metadataCollection: {
+            directory: path.join(root, buildRoot),
+            manifest: path.join(root, buildRoot, 'blocks-manifest.php'),
+            key: '',
+          },
+        }
+      : {}),
+  };
+}
+
+/**
+ * Plan an existing integration. Unknown and ambiguous layouts intentionally throw before a
+ * target is created; the attached profile explicitly offers standalone output.
+ */
+export async function planExistingPluginOutput(
+  hostDirectory: string,
+  generated: GeneratedBlockPackage,
+): Promise<PluginOutputPlan> {
+  const profile = await detectWpScriptsPlugin(hostDirectory);
+  if (profile.kind !== 'recognized') {
+    throw new UnsupportedPluginLayoutError(profile);
+  }
+  const block = normalizeGeneratedBlock(generated);
+  const blockLeaf = blockDirectoryName(block.name);
+  const sourceDirectory = path.join(profile.root, ...profile.blockDirectory.split('/'), blockLeaf);
+  const buildDirectory = path.join(profile.root, ...profile.buildDirectory.split('/'), blockLeaf);
+  const touchedFiles: PluginTouchedFile[] = [];
+
+  for (const [relativePath, content] of Object.entries(block.files).sort(([left], [right]) => left.localeCompare(right))) {
+    const target = path.join(sourceDirectory, ...relativePath.split('/'));
+    touchedFiles.push(await makeTouchedFile(profile.root, target, `${profile.blockDirectory}/${blockLeaf}/${relativePath}`, content));
+  }
+
+  const notes = [
+    `Block source target: ${sourceDirectory}`,
+    `Build target after npm run build: ${buildDirectory}`,
+    `Entry discovery: ${profile.entryDiscovery}`,
+  ];
+
+  if (profile.registration === 'direct') {
+    const bootstrap = (await readFile(profile.registrationFile)).toString('utf8');
+    const direct = directInsertion(bootstrap, profile.buildRoot, blockLeaf);
+    if (!direct) {
+      throw new UnsupportedPluginLayoutError(unsupported(
+        'unsupported',
+        profile.root,
+        `The direct registration bootstrap ${profile.registrationFile} cannot be extended safely.`,
+      ));
+    }
+    touchedFiles.push(await makeModifiedFile(profile.root, profile.registrationFile, direct));
+    notes.push(`Direct registration target: ${buildDirectory}`);
+  } else {
+    const bootstrap = (await readFile(profile.registrationFile)).toString('utf8');
+    const metadataCollectionKey = metadataCollectionKeyFor(profile.buildRoot, profile.buildDirectory, blockLeaf);
+    const update = collectionBootstrapUpdate(bootstrap, profile.buildRoot, metadataCollectionKey);
+    if (!update) {
+      throw new UnsupportedPluginLayoutError(unsupported(
+        'unsupported',
+        profile.root,
+        `The metadata collection bootstrap ${profile.registrationFile} cannot be extended safely.`,
+      ));
+    }
+    if (update !== bootstrap) {
+      touchedFiles.push(await makeModifiedFile(profile.root, profile.registrationFile, update));
+    }
+    if (!hasBlocksManifest(profile.buildScript)) {
+      const packageText = (await readFile(profile.packageFile)).toString('utf8');
+      const updatedPackage = appendBlocksManifest(packageText);
+      if (!updatedPackage) {
+        throw new UnsupportedPluginLayoutError(unsupported(
+          'unsupported',
+          profile.root,
+          'The build script could not be updated to generate blocks-manifest.php safely.',
+        ));
+      }
+      touchedFiles.push(await makeModifiedFile(profile.root, profile.packageFile, updatedPackage));
+      notes.push('The existing build script gains --blocks-manifest so the collection includes the new build directory.');
+    }
+    const metadataCollection = {
+      directory: path.join(profile.root, profile.buildRoot),
+      manifest: path.join(profile.root, profile.buildRoot, 'blocks-manifest.php'),
+      key: metadataCollectionKey,
+    };
+    profile.metadataCollection = metadataCollection;
+    notes.push(
+      `Metadata collection: ${metadataCollection.manifest} (key ${JSON.stringify(block.name)}, directory ${buildDirectory})`,
+    );
+  }
+
+  return finalizePlan({
+    mode: 'existing',
+    targetDirectory: sourceDirectory,
+    block: { name: block.name, directory: sourceDirectory, buildDirectory },
+    profile,
+    touchedFiles,
+    notes,
+  });
+}
+
+/** Build a complete standalone wp-scripts plugin plan. No files are created until writePluginOutput. */
+export async function planStandalonePluginOutput(
+  outputDirectory: string,
+  generated: GeneratedBlockPackage,
+): Promise<PluginOutputPlan> {
+  const root = path.resolve(outputDirectory);
+  const block = normalizeGeneratedBlock(generated);
+  const pluginSlug = pluginDirectoryName(block.name);
+  const blockLeaf = blockDirectoryName(block.name);
+  const sourceDirectory = path.join(root, 'src', 'blocks', blockLeaf);
+  const buildDirectory = path.join(root, 'build', 'blocks', blockLeaf);
+  const textDomain = pluginSlug;
+  const displayName = titleFromSlug(pluginSlug);
+  const touchedFiles: PluginTouchedFile[] = [];
+
+  const files: Record<string, string> = {
+    'package.json': standalonePackageJson(pluginSlug),
+    'package-lock.json': standalonePackageLock(pluginSlug),
+    'plugin.php': standaloneBootstrap({ pluginSlug, displayName, textDomain, blockName: block.name, blockLeaf }),
+    'readme.txt': standaloneReadme(displayName, pluginSlug),
+    '.distignore': standaloneDistIgnore(),
+    'scripts/verify-zip.mjs': standaloneZipVerifier(
+      pluginSlug,
+      blockLeaf,
+      runtimeFilesFromBlockMetadata(toBuffer(block.files['block.json']!)),
+    ),
+  };
+  for (const [relativePath, content] of Object.entries(files)) {
+    const target = path.join(root, ...relativePath.split('/'));
+    touchedFiles.push(await makeTouchedFile(root, target, relativePath, content));
+  }
+  for (const [relativePath, content] of Object.entries(block.files).sort(([left], [right]) => left.localeCompare(right))) {
+    const target = path.join(sourceDirectory, ...relativePath.split('/'));
+    touchedFiles.push(await makeTouchedFile(root, target, `src/blocks/${blockLeaf}/${relativePath}`, content));
+  }
+
+  return finalizePlan({
+    mode: 'standalone',
+    targetDirectory: root,
+    block: { name: block.name, directory: sourceDirectory, buildDirectory },
+    touchedFiles,
+    notes: [
+      `Standalone plugin target: ${root}`,
+      `Block source target: ${sourceDirectory}`,
+      `Build target after npm run build: ${buildDirectory}`,
+      `The release ZIP is ${pluginSlug}.zip and is checked by npm run test:zip.`,
+      `ZIP policy excludes source, dependencies, VCS files, local environment files, logs, and nested archives.`,
+    ],
+  });
+}
+
+/**
+ * Materialize a previously previewed plan. Existing files are never replaced unless their exact
+ * preview paths appear in authorizedReplacements. All targets are checked before the first write.
+ */
+export async function writePluginOutput(
+  plan: PluginOutputPlan,
+  options: WritePluginOutputOptions = {},
+): Promise<WritePluginOutputResult> {
+  const root = path.resolve(plan.mode === 'standalone' ? plan.targetDirectory : plan.profile!.root);
+  const approved = new Set(options.authorizedReplacements ?? []);
+  if (fingerprintPlan(plan) !== plan.fingerprint) {
+    throw new Error('Plugin output plan changed after preview; create and approve a new preview before writing.');
+  }
+
+  // Complete inspection happens before directory creation or file mutation.
+  for (const file of plan.touchedFiles) {
+    assertTargetInside(root, file.path);
+    await assertNoSymlinkedParents(root, file.path);
+    const stats = await lstatMaybe(file.path);
+    if (file.operation === 'create') {
+      if (stats) {
+        throw new Error(`Refusing to replace existing file without a separately authorized preview: ${file.path}`);
+      }
+      continue;
+    }
+    if (!stats?.isFile()) {
+      throw new Error(`Previewed file is no longer a regular file: ${file.path}`);
+    }
+    if (!file.requiresSeparateAuthorization || !approved.has(file.path)) {
+      throw new Error(`Separate explicit authorization is required to replace: ${file.path}`);
+    }
+    const current = await readFile(file.path);
+    if (!current.equals(file.previousContent!)) {
+      throw new Error(`Previewed file changed after inspection: ${file.path}`);
+    }
+  }
+
+  const staged: Array<{ temporary: string; target: string; mode: number }> = [];
+  const written: string[] = [];
+  try {
+    for (const file of plan.touchedFiles) {
+      await mkdir(path.dirname(file.path), { recursive: true });
+      await assertNoSymlinkedParents(root, file.path);
+      if (file.operation === 'create') {
+        await writeFile(file.path, file.content, { flag: 'wx', mode: 0o644 });
+        written.push(file.path);
+      } else {
+        const targetStats = await lstatMaybe(file.path);
+        if (!targetStats?.isFile()) {
+          throw new Error(`Previewed file is no longer a regular file: ${file.path}`);
+        }
+        const temporary = path.join(path.dirname(file.path), `.${path.basename(file.path)}.block-runner-${randomUUID()}.tmp`);
+        const mode = targetStats.mode & 0o777;
+        await writeFile(temporary, file.content, { flag: 'wx', mode });
+        await chmod(temporary, mode);
+        staged.push({ temporary, target: file.path, mode });
+      }
+    }
+    for (const item of staged) {
+      const current = await readFile(item.target);
+      const preview = plan.touchedFiles.find((file) => file.path === item.target)!;
+      if (!current.equals(preview.previousContent!)) {
+        throw new Error(`Previewed file changed before replacement: ${item.target}`);
+      }
+      await rename(item.temporary, item.target);
+      // rename(2) preserves the temporary file's mode. Keep the target mode explicit in case a
+      // platform's creation mask changed it while the temporary file was written.
+      await chmod(item.target, item.mode);
+      written.push(item.target);
+    }
+    if (plan.mode === 'standalone') {
+      await writeStandaloneDependencyLock(root);
+    }
+  } finally {
+    await Promise.all(staged.map(async ({ temporary }) => {
+      try {
+        await unlink(temporary);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw error;
+        }
+      }
+    }));
+  }
+  return { directory: root, written: written.sort(), fingerprint: plan.fingerprint };
+}
+
+/** A narrow archive policy check for the standalone release lane. */
+export function assertStandaloneZipEntries(
+  entries: readonly string[],
+  blockDirectory: string,
+  runtimeFiles: readonly string[] = [],
+): void {
+  const normalized = stripArchiveRoot(entries);
+  const blockRoot = `build/blocks/${blockDirectory}`;
+  const required = [
+    'plugin.php',
+    'readme.txt',
+    `${blockRoot}/block.json`,
+    ...runtimeFiles.map((file) => `${blockRoot}/${normalizeRuntimeFile(file)}`),
+  ];
+  for (const file of required) {
+    if (!normalized.includes(file)) {
+      throw new Error(`Standalone ZIP is missing runtime file: ${file}`);
+    }
+  }
+  const forbidden = /^(?:node_modules|src|scripts|\.git|\.github)(?:\/|$)|(?:^|\/)\.env(?:\.|$)|(?:^|\/)[^/]*\.(?:log|zip)$/i;
+  const accidental = normalized.find((entry) => forbidden.test(entry));
+  if (accidental) {
+    throw new Error(`Standalone ZIP contains excluded local/private file: ${accidental}`);
+  }
+  const unexpected = normalized.find((entry) => entry !== 'plugin.php' && entry !== 'readme.txt' && entry !== 'package.json' && !entry.startsWith('build/'));
+  if (unexpected) {
+    throw new Error(`Standalone ZIP contains a file outside its runtime allowlist: ${unexpected}`);
+  }
+}
+
+function unsupported(kind: UnsupportedPluginProfile['kind'], root: string, reason: string): UnsupportedPluginProfile {
+  return { kind, root, reason, standaloneAvailable: true };
+}
+
+function asObject(value: unknown, message: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(message);
+  }
+  return value as Record<string, unknown>;
+}
+
+function asObjectOrEmpty(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function isWpScriptsBuild(command: string): boolean {
+  return /^\s*wp-scripts\s+build(?:\s|$)/.test(command);
+}
+
+function commandPath(command: string, option: 'source-path' | 'output-path'): string | undefined {
+  const match = command.match(new RegExp(`--${option}(?:=|\\s+)([^\\s]+)`));
+  return match?.[1]?.replace(/^['"]|['"]$/g, '');
+}
+
+function isSafeRelativeDirectory(value: string): boolean {
+  return value !== '.' && !value.includes('\\') && !path.posix.isAbsolute(value) && !path.win32.isAbsolute(value)
+    && value.split('/').every((part) => part.length > 0 && part !== '.' && part !== '..');
+}
+
+function isSafeRelativeFile(value: string): boolean {
+  return isSafeRelativeDirectory(value) || (!value.includes('\\') && !path.posix.isAbsolute(value) && !path.win32.isAbsolute(value)
+    && value.split('/').every((part) => part.length > 0 && part !== '.' && part !== '..'));
+}
+
+function commonDirectory(directories: readonly string[]): string {
+  const split = directories.map((directory) => directory === '.' ? [] : directory.split('/'));
+  const first = split[0] ?? [];
+  const common: string[] = [];
+  for (let index = 0; index < first.length; index += 1) {
+    const component = first[index]!;
+    if (split.every((parts) => parts[index] === component)) common.push(component);
+    else break;
+  }
+  return common.join('/');
+}
+
+function joinPosix(left: string, right: string): string {
+  return right ? `${left}/${right}` : left;
+}
+
+async function findBlockMetadata(root: string): Promise<string[]> {
+  const found: string[] = [];
+  async function walk(directory: string, prefix = ''): Promise<void> {
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === '.git') continue;
+      const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) await walk(path.join(directory, entry.name), relative);
+      else if (entry.isFile() && entry.name === 'block.json') found.push(relative);
+    }
+  }
+  await walk(root);
+  return found.sort();
+}
+
+/** wp-scripts loads these root files without them appearing in package.json. */
+async function findAutomaticWebpackConfig(root: string): Promise<string | undefined> {
+  for (const name of ['webpack.config.js', 'webpack.config.babel.js']) {
+    if (await lstatMaybe(path.join(root, name))) return name;
+  }
+  return undefined;
+}
+
+async function findPhpFiles(root: string): Promise<string[]> {
+  const found: string[] = [];
+  async function walk(directory: string, relative = ''): Promise<void> {
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      if (['node_modules', '.git', 'build', 'src', 'vendor'].includes(entry.name)) continue;
+      const childRelative = relative ? `${relative}/${entry.name}` : entry.name;
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) await walk(absolute, childRelative);
+      else if (entry.isFile() && entry.name.endsWith('.php')) found.push(childRelative);
+    }
+  }
+  await walk(root);
+  return found.sort();
+}
+
+async function findDirectRegistration(root: string, phpFiles: readonly string[], buildRoot: string): Promise<{ file: string } | undefined> {
+  const candidates: string[] = [];
+  const escapedBuild = escapeRegex(buildRoot);
+  const pattern = new RegExp(`register_block_type\\s*\\(\\s*__DIR__\\s*\\.\\s*(['"])\\/${escapedBuild}(?:\\/[^'"]+)?\\1\\s*\\)`, 'g');
+  for (const relative of phpFiles) {
+    const file = path.join(root, ...relative.split('/'));
+    if (pattern.test((await readFile(file)).toString('utf8'))) candidates.push(file);
+    pattern.lastIndex = 0;
+  }
+  if (candidates.length > 1) return undefined;
+  return candidates.length === 1 ? { file: candidates[0]! } : undefined;
+}
+
+async function findCollectionRegistration(root: string, phpFiles: readonly string[], buildRoot: string): Promise<{ file: string } | undefined> {
+  const candidates: string[] = [];
+  const buildLiteral = `/${buildRoot}`;
+  for (const relative of phpFiles) {
+    const file = path.join(root, ...relative.split('/'));
+    const content = (await readFile(file)).toString('utf8');
+    if (
+      /wp_register_block_metadata_collection\s*\(/.test(content)
+      && content.includes(buildLiteral)
+      && /blocks-manifest\.php/.test(content)
+      && ( /wp_register_block_types_from_metadata_collection\s*\(/.test(content)
+        || /register_block_type_from_metadata_collection\s*\(/.test(content) )
+    ) candidates.push(file);
+  }
+  if (candidates.length > 1) return undefined;
+  return candidates.length === 1 ? { file: candidates[0]! } : undefined;
+}
+
+function normalizeGeneratedBlock(input: GeneratedBlockPackage): GeneratedBlockPackage {
+  if (!input || typeof input.name !== 'string' || !/^[a-z0-9][a-z0-9-]*\/[a-z0-9][a-z0-9-]*$/.test(input.name)) {
+    throw new Error('Generated block must have a lowercase namespace/name block name.');
+  }
+  if (!input.files || typeof input.files !== 'object' || Array.isArray(input.files) || !Object.prototype.hasOwnProperty.call(input.files, 'block.json')) {
+    throw new Error('Generated block must include block.json.');
+  }
+  const files: Record<string, Buffer> = {};
+  for (const [file, content] of Object.entries(input.files)) {
+    if (!isSafeRelativeFile(file) || (typeof content !== 'string' && !Buffer.isBuffer(content))) {
+      throw new Error(`Generated block contains an unsafe file: ${JSON.stringify(file)}`);
+    }
+    files[file] = Buffer.isBuffer(content) ? Buffer.from(content) : Buffer.from(content, 'utf8');
+  }
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(files['block.json']!.toString('utf8'));
+  } catch {
+    throw new Error('Generated block block.json is not valid JSON.');
+  }
+  if (!metadata || typeof metadata !== 'object' || (metadata as { name?: unknown }).name !== input.name) {
+    throw new Error('Generated block block.json name does not match the generated block name.');
+  }
+  return { name: input.name, files };
+}
+
+function blockDirectoryName(blockName: string): string {
+  return blockName.split('/')[1]!;
+}
+
+function pluginDirectoryName(blockName: string): string {
+  return `${blockName.split('/')[0]!}-${blockDirectoryName(blockName)}`;
+}
+
+function metadataCollectionKeyFor(buildRoot: string, buildDirectory: string, blockLeaf: string): string {
+  const outputDirectory = path.posix.join(buildDirectory, blockLeaf);
+  const key = path.posix.relative(buildRoot, outputDirectory);
+  if (!isSafeRelativeDirectory(key)) {
+    throw new Error(`Generated block build directory cannot be represented as a metadata collection key: ${outputDirectory}`);
+  }
+  return key;
+}
+
+/**
+ * WordPress block metadata may name any runtime asset with `file:./…`. Preserve those paths
+ * verbatim (apart from removing the harmless leading `./`) so the release test reflects the
+ * actual block contract rather than a convention such as `index.js`.
+ */
+function runtimeFilesFromBlockMetadata(metadataFile: Buffer): string[] {
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(metadataFile.toString('utf8'));
+  } catch {
+    throw new Error('Generated block block.json is not valid JSON.');
+  }
+  const files = new Set<string>();
+  const visit = (value: unknown): void => {
+    if (typeof value === 'string' && value.startsWith('file:')) {
+      files.add(normalizeRuntimeFile(value.slice('file:'.length)));
+    } else if (Array.isArray(value)) {
+      value.forEach(visit);
+    } else if (value && typeof value === 'object') {
+      Object.values(value).forEach(visit);
+    }
+  };
+  visit(metadata);
+  return [...files].sort();
+}
+
+function normalizeRuntimeFile(value: string): string {
+  const normalized = path.posix.normalize(value.replace(/\\/g, '/')).replace(/^\.\//, '');
+  if (!isSafeRelativeFile(normalized)) {
+    throw new Error(`Generated block metadata references an unsafe local file: ${JSON.stringify(value)}`);
+  }
+  return normalized;
+}
+
+function toBuffer(content: PluginFileContent): Buffer {
+  return Buffer.isBuffer(content) ? Buffer.from(content) : Buffer.from(content, 'utf8');
+}
+
+function stripArchiveRoot(entries: readonly string[]): string[] {
+  const normalized = entries
+    .map((entry) => entry.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/$/, ''))
+    .filter(Boolean);
+  if (normalized.includes('plugin.php')) return normalized;
+
+  const rootedPlugin = normalized.find((entry) => /^[^/]+\/plugin\.php$/.test(entry));
+  if (!rootedPlugin) return normalized;
+
+  const root = rootedPlugin.slice(0, -'/plugin.php'.length);
+  const prefix = `${root}/`;
+  const outsideRoot = normalized.find((entry) => !entry.startsWith(prefix));
+  if (outsideRoot) {
+    throw new Error(`Standalone ZIP contains an entry outside its plugin root: ${outsideRoot}`);
+  }
+  return normalized.map((entry) => entry.slice(prefix.length));
+}
+
+async function makeTouchedFile(root: string, target: string, relativePath: string, content: PluginFileContent): Promise<PluginTouchedFile> {
+  assertTargetInside(root, target);
+  const rawContent = toBuffer(content);
+  const existing = await lstatMaybe(target);
+  if (existing) {
+    if (!existing.isFile()) throw new Error(`Planned plugin target is not a regular file: ${target}`);
+    return {
+      path: target,
+      relativePath,
+      operation: 'modify',
+      content: rawContent,
+      previousContent: await readFile(target),
+      requiresSeparateAuthorization: true,
+    };
+  }
+  return { path: target, relativePath, operation: 'create', content: rawContent, requiresSeparateAuthorization: false };
+}
+
+async function makeModifiedFile(root: string, target: string, content: PluginFileContent): Promise<PluginTouchedFile> {
+  const file = await makeTouchedFile(root, target, path.relative(root, target).split(path.sep).join('/'), content);
+  if (file.operation !== 'modify') throw new Error(`Expected existing bootstrap file is missing: ${target}`);
+  return file;
+}
+
+function directInsertion(bootstrap: string, buildRoot: string, blockLeaf: string): string | undefined {
+  const pathLiteral = `/${buildRoot}/${blockLeaf}`;
+  const pattern = new RegExp(`register_block_type\\s*\\(\\s*__DIR__\\s*\\.\\s*(['"])\\/${escapeRegex(buildRoot)}(?:\\/[^'"]+)?\\1\\s*\\)\\s*;?`, 'g');
+  const matches = [...bootstrap.matchAll(pattern)];
+  const last = matches.at(-1);
+  if (!last || last.index === undefined) return undefined;
+  const lineStart = bootstrap.lastIndexOf('\n', last.index) + 1;
+  const indent = bootstrap.slice(lineStart, last.index).match(/^\s*/)?.[0] ?? '';
+  const insertion = `${last[0]}\n${indent}register_block_type( __DIR__ . '${pathLiteral}' );`;
+  return `${bootstrap.slice(0, last.index)}${insertion}${bootstrap.slice(last.index + last[0].length)}`;
+}
+
+function collectionBootstrapUpdate(bootstrap: string, buildRoot: string, blockName: string): string | undefined {
+  if (!/wp_register_block_metadata_collection\s*\(/.test(bootstrap) || !bootstrap.includes(`/${buildRoot}`) || !/blocks-manifest\.php/.test(bootstrap)) {
+    return undefined;
+  }
+  // The bulk 6.8 API receives all entries from the generated manifest, so no PHP change is
+  // needed. The manifest's key is the output-root-relative block directory calculated above.
+  if (/wp_register_block_types_from_metadata_collection\s*\(/.test(bootstrap)) return bootstrap;
+  const pattern = /register_block_type_from_metadata_collection\s*\(\s*([^,]+),\s*(['"])[^'"]+\2\s*\)\s*;?/g;
+  const matches = [...bootstrap.matchAll(pattern)];
+  const last = matches.at(-1);
+  if (!last || last.index === undefined) return undefined;
+  const lineStart = bootstrap.lastIndexOf('\n', last.index) + 1;
+  const indent = bootstrap.slice(lineStart, last.index).match(/^\s*/)?.[0] ?? '';
+  const insertion = `${last[0]}\n${indent}register_block_type_from_metadata_collection( ${last[1]!.trim()}, '${blockName}' );`;
+  return `${bootstrap.slice(0, last.index)}${insertion}${bootstrap.slice(last.index + last[0].length)}`;
+}
+
+function hasBlocksManifest(command: string): boolean {
+  return /--blocks-manifest(?:\s|$)/.test(command);
+}
+
+function appendBlocksManifest(packageText: string): string | undefined {
+  // Change precisely the JSON string that backs `scripts.build`; formatting and all unrelated
+  // package fields remain byte-for-byte intact.
+  const match = packageText.match(/("build"\s*:\s*")((?:\\.|[^"\\])*)(")/);
+  if (!match || !isWpScriptsBuild(match[2]!.replace(/\\"/g, '"'))) return undefined;
+  const command = match[2]!;
+  if (hasBlocksManifest(command)) return packageText;
+  return `${packageText.slice(0, match.index!)}${match[1]}${command} --blocks-manifest${match[3]}${packageText.slice(match.index! + match[0].length)}`;
+}
+
+function finalizePlan(input: Omit<PluginOutputPlan, 'fingerprint'>): PluginOutputPlan {
+  const duplicate = input.touchedFiles.find((file, index, all) => all.findIndex((candidate) => candidate.path === file.path) !== index);
+  if (duplicate) throw new Error(`Plugin preview has duplicate target: ${duplicate.path}`);
+  const plan = { ...input, touchedFiles: [...input.touchedFiles].sort((left, right) => left.path.localeCompare(right.path)), fingerprint: '' };
+  return { ...plan, fingerprint: fingerprintPlan(plan) };
+}
+
+function fingerprintPlan(plan: Omit<PluginOutputPlan, 'fingerprint'> | PluginOutputPlan): string {
+  const view = {
+    mode: plan.mode,
+    targetDirectory: plan.targetDirectory,
+    block: plan.block,
+    profile: plan.profile && {
+      root: plan.profile.root,
+      sourceRoot: plan.profile.sourceRoot,
+      buildRoot: plan.profile.buildRoot,
+      registration: plan.profile.registration,
+      metadataCollection: plan.profile.metadataCollection,
+    },
+    touchedFiles: plan.touchedFiles.map((file) => ({
+      path: file.path,
+      operation: file.operation,
+      content: file.content,
+      previousContent: file.previousContent,
+    })),
+  };
+  return createHash('sha256').update(JSON.stringify(view)).digest('hex');
+}
+
+function assertTargetInside(root: string, target: string): void {
+  const resolvedRoot = path.resolve(root);
+  const resolvedTarget = path.resolve(target);
+  if (!resolvedTarget.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error(`Plugin target resolves outside its approved directory: ${target}`);
+  }
+}
+
+async function assertNoSymlinkedParents(root: string, target: string): Promise<void> {
+  const resolvedRoot = path.resolve(root);
+  const relative = path.relative(resolvedRoot, path.resolve(target));
+  let current = resolvedRoot;
+  const rootStats = await lstatMaybe(current);
+  if (rootStats?.isSymbolicLink()) throw new Error(`Plugin target root is a symbolic link: ${root}`);
+  for (const part of relative.split(path.sep).slice(0, -1)) {
+    current = path.join(current, part);
+    const stats = await lstatMaybe(current);
+    if (!stats) return;
+    if (stats.isSymbolicLink()) throw new Error(`Plugin target parent is a symbolic link: ${current}`);
+    if (!stats.isDirectory()) throw new Error(`Plugin target parent is not a directory: ${current}`);
+  }
+}
+
+async function lstatMaybe(file: string) {
+  try {
+    return await lstat(file);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function titleFromSlug(slug: string): string {
+  return slug.split('-').map((part) => part.slice(0, 1).toUpperCase() + part.slice(1)).join(' ');
+}
+
+async function writeStandaloneDependencyLock(root: string): Promise<void> {
+  try {
+    // `--package-lock-only` resolves the exact transitive tree without leaving a node_modules
+    // directory in the generated plugin. Its subsequent `npm ci` therefore installs the pinned
+    // local wp-scripts binary rather than having a build script download one through npx.
+    await execFileAsync('npm', [
+      'install',
+      '--package-lock-only',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+    ], { cwd: root });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Could not resolve the standalone @wordpress/scripts dependency lock: ${detail}`);
+  }
+}
+
+function standalonePackageJson(pluginSlug: string): string {
+  return `${JSON.stringify({
+    name: pluginSlug,
+    version: '0.1.0',
+    private: true,
+    description: 'A WordPress block plugin generated by Block Runner.',
+    license: 'GPL-2.0-or-later',
+    engines: { node: '>=20' },
+    packageManager: 'npm@11.6.2',
+    files: ['build', 'plugin.php', 'readme.txt'],
+    devDependencies: {
+      '@wordpress/scripts': STANDALONE_WP_SCRIPTS_VERSION,
+    },
+    scripts: {
+      build: 'wp-scripts build --source-path=src --output-path=build --blocks-manifest',
+      zip: 'npm run build && wp-scripts plugin-zip',
+      'test:zip': `node scripts/verify-zip.mjs ${pluginSlug}.zip`,
+    },
+  }, null, 2)}\n`;
+}
+
+function standalonePackageLock(pluginSlug: string): string {
+  // This seed is replaced with npm's complete dependency tree by writePluginOutput before the
+  // generated project is returned. Keeping it in the preview exposes every file up front.
+  return `${JSON.stringify({
+    name: pluginSlug,
+    version: '0.1.0',
+    lockfileVersion: 3,
+    requires: true,
+    packages: {
+      '': {
+        name: pluginSlug,
+        version: '0.1.0',
+        license: 'GPL-2.0-or-later',
+        engines: { node: '>=20' },
+        devDependencies: { '@wordpress/scripts': STANDALONE_WP_SCRIPTS_VERSION },
+      },
+    },
+  }, null, 2)}\n`;
+}
+
+function standaloneBootstrap(input: { pluginSlug: string; displayName: string; textDomain: string; blockName: string; blockLeaf: string }): string {
+  return `<?php\n/**\n * Plugin Name: ${input.displayName}\n * Description: A registered block generated by Block Runner.\n * Version: 0.1.0\n * Requires at least: 6.8\n * Requires PHP: 7.2\n * Text Domain: ${input.textDomain}\n * License: GPL-2.0-or-later\n */\n\ndefined( 'ABSPATH' ) || exit;\n\nfunction ${input.pluginSlug.replace(/-/g, '_')}_register_blocks() {\n\t$build_dir = __DIR__ . '/build';\n\t$manifest = $build_dir . '/blocks-manifest.php';\n\n\tif ( function_exists( 'wp_register_block_metadata_collection' ) && file_exists( $manifest ) ) {\n\t\twp_register_block_metadata_collection( $build_dir, $manifest );\n\t\twp_register_block_types_from_metadata_collection( $build_dir, $manifest );\n\t\treturn;\n\t}\n\n\tregister_block_type( $build_dir . '/blocks/${input.blockLeaf}' );\n}\nadd_action( 'init', '${input.pluginSlug.replace(/-/g, '_')}_register_blocks' );\n`;
+}
+
+function standaloneReadme(displayName: string, pluginSlug: string): string {
+  return `=== ${displayName} ===\nContributors: ${pluginSlug}\nTags: block, editor\nRequires at least: 6.8\nTested up to: 6.8\nRequires PHP: 7.2\nStable tag: 0.1.0\nLicense: GPL-2.0-or-later\n\nA standalone registered block plugin generated by Block Runner.\n\n== Build a release ==\n\nRun npm ci, npm run zip, then npm run test:zip. Upload the generated ZIP from a clean checkout.\n`;
+}
+
+function standaloneDistIgnore(): string {
+  return `node_modules/\nsrc/\nscripts/\n.git/\n.github/\n.env\n.env.*\n*.log\n*.zip\npackage.json\npackage-lock.json\n`;
+}
+
+function standaloneZipVerifier(pluginSlug: string, blockLeaf: string, runtimeFiles: readonly string[]): string {
+  const runtime = runtimeFiles.map((file) => `build/blocks/${blockLeaf}/${file}`);
+  return `import { execFileSync } from 'node:child_process';\n\nconst zip = process.argv[2] || '${pluginSlug}.zip';\nconst initialEntries = execFileSync( 'unzip', [ '-Z1', zip ], { encoding: 'utf8' } )\n\t.split( /\\r?\\n/ )\n\t.filter( Boolean )\n\t.map( ( entry ) => entry.replace( /^\\.\\//, '' ).replace( /\\/$/, '' ) )\n\t.filter( Boolean );\nconst rootedPlugin = initialEntries.find( ( entry ) => /^[^/]+\\/plugin\\.php$/.test( entry ) );\nconst root = rootedPlugin ? rootedPlugin.slice( 0, -'/plugin.php'.length ) : undefined;\nif ( root && initialEntries.some( ( entry ) => ! entry.startsWith( root + '/' ) ) ) {\n\tthrow new Error( 'Release ZIP contains an entry outside its plugin root.' );\n}\nconst entries = root ? initialEntries.map( ( entry ) => entry.slice( root.length + 1 ) ) : initialEntries;\nconst required = ${JSON.stringify(['plugin.php', 'readme.txt', `build/blocks/${blockLeaf}/block.json`, ...runtime])};\nfor ( const entry of required ) {\n\tif ( ! entries.includes( entry ) ) throw new Error( \`Release ZIP is missing runtime file: \${entry}\` );\n}\nconst forbidden = /^(?:node_modules|src|scripts|\\.git|\\.github)(?:\\/|$)|(?:^|\\/)\\.env(?:\\.|$)|(?:^|\\/)[^/]*\\.(?:log|zip)$/i;\nconst accidental = entries.find( ( entry ) => forbidden.test( entry ) );\nif ( accidental ) throw new Error( \`Release ZIP contains excluded local/private file: \${accidental}\` );\nconst unexpected = entries.find( ( entry ) => entry !== 'plugin.php' && entry !== 'readme.txt' && entry !== 'package.json' && ! entry.startsWith( 'build/' ) );\nif ( unexpected ) throw new Error( \`Release ZIP contains a file outside its runtime allowlist: \${unexpected}\` );\nconsole.log( \`ZIP policy passed: \${zip}\` );\n`;
+}

--- a/test/plugin.profile.test.ts
+++ b/test/plugin.profile.test.ts
@@ -98,6 +98,15 @@ describe('wp-scripts plugin profile', () => {
     await expect(stat(path.join(root, 'src'))).rejects.toThrow();
   });
 
+  it('rejects positional wp-scripts build entries because they bypass metadata entry discovery', async () => {
+    const root = await existingDefaultDirectPlugin('wp-scripts build custom.js');
+
+    await expect(detectWpScriptsPlugin(root)).resolves.toMatchObject({
+      kind: 'unsupported',
+      standaloneAvailable: true,
+    });
+  });
+
   it('rejects version ranges and webpack configurations that wp-scripts loads implicitly', async () => {
     const ranged = await existingDirectPlugin();
     await writeFile(path.join(ranged, 'package.json'), JSON.stringify({
@@ -219,10 +228,22 @@ async function existingDirectPlugin(): Promise<string> {
   const root = await mkdtemp(path.join(tmpdir(), 'block-runner-plugin-'));
   await writeFile(path.join(root, 'package.json'), JSON.stringify({
     devDependencies: { '@wordpress/scripts': '34.2.0' },
-    scripts: { build: 'wp-scripts build --source-path=src/blocks --output-path=build/blocks' },
+    scripts: { build: 'wp-scripts build --source-path src/blocks --output-path build/blocks' },
   }, null, 2));
   await writeFile(path.join(root, 'main.php'), `<?php\nadd_action( 'init', function() {\n\tregister_block_type( __DIR__ . '/build/blocks/existing' );\n} );\n`);
   await writeSourceBlock(root, 'src/blocks/existing');
+  return root;
+}
+
+/** A valid default-roots host makes the positional-entry regression observable. */
+async function existingDefaultDirectPlugin(build: string): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'block-runner-plugin-'));
+  await writeFile(path.join(root, 'package.json'), JSON.stringify({
+    devDependencies: { '@wordpress/scripts': '34.2.0' },
+    scripts: { build },
+  }, null, 2));
+  await writeFile(path.join(root, 'main.php'), `<?php\nadd_action( 'init', function() {\n\tregister_block_type( __DIR__ . '/build/existing' );\n} );\n`);
+  await writeSourceBlock(root, 'src/existing');
   return root;
 }
 

--- a/test/plugin.profile.test.ts
+++ b/test/plugin.profile.test.ts
@@ -1,0 +1,247 @@
+import { execFile } from 'node:child_process';
+import { chmod, mkdtemp, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+import {
+  assertStandaloneZipEntries,
+  detectWpScriptsPlugin,
+  planExistingPluginOutput,
+  planStandalonePluginOutput,
+  UnsupportedPluginLayoutError,
+  writePluginOutput,
+} from '../src/plugin/profile.js';
+
+const execFileAsync = promisify(execFile);
+
+const block = {
+  name: 'acme/notice',
+  files: {
+    'block.json': JSON.stringify({
+      '$schema': 'https://schemas.wp.org/trunk/block.json',
+      apiVersion: 3,
+      name: 'acme/notice',
+      title: 'Notice',
+      category: 'widgets',
+      editorScript: 'file:./index.js',
+    }, null, 2),
+    'index.js': "import { registerBlockType } from '@wordpress/blocks';\nimport metadata from './block.json';\nregisterBlockType( metadata.name, { edit: () => 'Notice', save: () => 'Notice' } );\n",
+    'style.css': '.wp-block-acme-notice { color: rebeccapurple; }\n',
+  },
+};
+
+describe('wp-scripts plugin profile', () => {
+  it('recognises the direct registration profile and requires a separate bootstrap replacement approval', async () => {
+    const root = await existingDirectPlugin();
+    const profile = await detectWpScriptsPlugin(root);
+
+    expect(profile).toMatchObject({
+      kind: 'recognized',
+      wpScriptsVersion: '34.2.0',
+      sourceRoot: 'src/blocks',
+      buildRoot: 'build/blocks',
+      registration: 'direct',
+    });
+
+    const plan = await planExistingPluginOutput(root, block);
+    expect(plan.targetDirectory).toBe(path.join(root, 'src', 'blocks', 'notice'));
+    await expect(stat(path.join(root, 'src', 'blocks', 'notice'))).rejects.toThrow();
+    expect(plan.touchedFiles.map((file) => [file.relativePath, file.operation])).toEqual([
+      ['main.php', 'modify'],
+      ['src/blocks/notice/block.json', 'create'],
+      ['src/blocks/notice/index.js', 'create'],
+      ['src/blocks/notice/style.css', 'create'],
+    ]);
+    expect(plan.notes).toContain(`Build target after npm run build: ${path.join(root, 'build', 'blocks', 'notice')}`);
+    await expect(writePluginOutput(plan)).rejects.toThrow('Separate explicit authorization');
+    expect(await readFile(path.join(root, 'main.php'), 'utf8')).not.toContain("'/build/blocks/notice'");
+
+    const modified = plan.touchedFiles.filter((file) => file.operation === 'modify').map((file) => file.path);
+    await writePluginOutput(plan, { authorizedReplacements: modified });
+    expect(await readFile(path.join(root, 'main.php'), 'utf8')).toContain("register_block_type( __DIR__ . '/build/blocks/notice' );");
+    expect(await stat(path.join(root, 'src', 'blocks', 'notice', 'block.json'))).toBeTruthy();
+  });
+
+  it('extends a named metadata collection with the output-root-relative manifest key', async () => {
+    const root = await existingCollectionPlugin(false);
+    const plan = await planExistingPluginOutput(root, block);
+    const php = plan.touchedFiles.find((file) => file.relativePath === 'plugin.php');
+    const packageFile = plan.touchedFiles.find((file) => file.relativePath === 'package.json');
+
+    expect(plan.profile?.metadataCollection).toEqual({
+      directory: path.join(root, 'build'),
+      manifest: path.join(root, 'build', 'blocks-manifest.php'),
+      key: 'blocks/notice',
+    });
+    expect(php?.content.toString()).toContain("register_block_type_from_metadata_collection( $build_dir, 'blocks/notice' );");
+    expect(packageFile?.content.toString()).toContain('--blocks-manifest');
+    expect(plan.touchedFiles.every((file) => path.isAbsolute(file.path))).toBe(true);
+  });
+
+  it('does not edit a bulk metadata bootstrap and relies on the generated blocks manifest', async () => {
+    const root = await existingCollectionPlugin(true);
+    const plan = await planExistingPluginOutput(root, block);
+
+    expect(plan.touchedFiles.some((file) => file.relativePath === 'plugin.php')).toBe(false);
+    expect(plan.profile?.metadataCollection?.key).toBe('blocks/notice');
+    expect(plan.notes.join('\n')).toContain('blocks-manifest.php');
+  });
+
+  it('fails unsupported layouts before writes and exposes the standalone choice', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'block-runner-plugin-'));
+    await writeFile(path.join(root, 'package.json'), JSON.stringify({ scripts: { build: 'vite build' } }));
+
+    const profile = await detectWpScriptsPlugin(root);
+    expect(profile).toMatchObject({ kind: 'unsupported', standaloneAvailable: true });
+    await expect(planExistingPluginOutput(root, block)).rejects.toBeInstanceOf(UnsupportedPluginLayoutError);
+    await expect(stat(path.join(root, 'src'))).rejects.toThrow();
+  });
+
+  it('rejects version ranges and webpack configurations that wp-scripts loads implicitly', async () => {
+    const ranged = await existingDirectPlugin();
+    await writeFile(path.join(ranged, 'package.json'), JSON.stringify({
+      devDependencies: { '@wordpress/scripts': '^34.2.0' },
+      scripts: { build: 'wp-scripts build --source-path=src/blocks --output-path=build/blocks' },
+    }));
+    await expect(detectWpScriptsPlugin(ranged)).resolves.toMatchObject({ kind: 'unsupported' });
+
+    const configured = await existingDirectPlugin();
+    await writeFile(path.join(configured, 'webpack.config.babel.js'), 'module.exports = {};\n');
+    await expect(detectWpScriptsPlugin(configured)).resolves.toMatchObject({
+      kind: 'unsupported',
+      reason: expect.stringContaining('webpack.config.babel.js'),
+    });
+  });
+
+  it('preserves replacement modes and writes binary generated assets byte-for-byte', async () => {
+    const root = await existingDirectPlugin();
+    const bootstrap = path.join(root, 'main.php');
+    await chmod(bootstrap, 0o640);
+    const font = Buffer.from([0, 255, 4, 0, 128, 18]);
+    const binaryBlock = { ...block, files: { ...block.files, 'assets/notice.woff2': font } };
+
+    const plan = await planExistingPluginOutput(root, binaryBlock);
+    const modified = plan.touchedFiles.filter((file) => file.operation === 'modify').map((file) => file.path);
+    await writePluginOutput(plan, { authorizedReplacements: modified });
+
+    expect((await stat(bootstrap)).mode & 0o777).toBe(0o640);
+    expect(await readFile(path.join(root, 'src', 'blocks', 'notice', 'assets', 'notice.woff2'))).toEqual(font);
+  });
+});
+
+describe('standalone plugin profile', () => {
+  it('plans a pinned clean-install wrapper, ZIP policy, runtime bootstrap, and every generated source file', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'block-runner-standalone-'));
+    const output = path.join(root, 'notice-plugin');
+    const plan = await planStandalonePluginOutput(output, block);
+
+    expect(plan.mode).toBe('standalone');
+    expect(plan.targetDirectory).toBe(output);
+    await expect(stat(output)).rejects.toThrow();
+    expect(plan.touchedFiles.map((file) => file.relativePath)).toEqual(expect.arrayContaining([
+      'package.json',
+      'package-lock.json',
+      'plugin.php',
+      'readme.txt',
+      '.distignore',
+      'scripts/verify-zip.mjs',
+      'src/blocks/notice/block.json',
+      'src/blocks/notice/index.js',
+      'src/blocks/notice/style.css',
+    ]));
+    const packageJson = plan.touchedFiles.find((file) => file.relativePath === 'package.json')!.content;
+    const lock = plan.touchedFiles.find((file) => file.relativePath === 'package-lock.json')!.content;
+    const bootstrap = plan.touchedFiles.find((file) => file.relativePath === 'plugin.php')!.content;
+    expect(JSON.parse(packageJson.toString('utf8'))).toMatchObject({ devDependencies: { '@wordpress/scripts': '34.2.0' } });
+    expect(JSON.parse(lock.toString('utf8'))).toMatchObject({
+      lockfileVersion: 3,
+      packages: { '': { name: 'acme-notice', devDependencies: { '@wordpress/scripts': '34.2.0' } } },
+    });
+    expect(bootstrap.toString()).toContain('wp_register_block_metadata_collection');
+    expect(bootstrap.toString()).toContain("register_block_type( $build_dir . '/blocks/notice' );");
+    expect(packageJson.toString()).not.toContain('npx');
+  });
+
+  it('validates every metadata runtime file and accepts the normal plugin-zip root folder', () => {
+    expect(() => assertStandaloneZipEntries([
+      'acme-notice/plugin.php',
+      'acme-notice/readme.txt',
+      'acme-notice/package.json',
+      'acme-notice/build/blocks/notice/block.json',
+      'acme-notice/build/blocks/notice/view.js',
+      'acme-notice/build/blocks/notice/style-index.css',
+    ], 'notice', ['view.js', 'style-index.css'])).not.toThrow();
+    expect(() => assertStandaloneZipEntries([
+      'plugin.php',
+      'readme.txt',
+      'build/blocks/notice/block.json',
+      'build/blocks/notice/view.js',
+    ], 'notice', ['view.js', 'style-index.css'])).toThrow('style-index.css');
+    expect(() => assertStandaloneZipEntries([
+      'plugin.php',
+      'readme.txt',
+      'build/blocks/notice/block.json',
+      '.env.production',
+    ], 'notice')).toThrow('excluded local/private file');
+    expect(() => assertStandaloneZipEntries([
+      'plugin.php',
+      'readme.txt',
+      'build/blocks/notice/block.json',
+      'notes/private.txt',
+    ], 'notice')).toThrow('runtime allowlist');
+  });
+
+  it('resolves, clean-installs, builds, and inspects the actual release archive', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'block-runner-release-'));
+    const output = path.join(root, 'notice-plugin');
+    const plan = await planStandalonePluginOutput(output, block);
+
+    await writePluginOutput(plan);
+    const lock = JSON.parse(await readFile(path.join(output, 'package-lock.json'), 'utf8')) as {
+      packages: Record<string, { version?: string }>;
+    };
+    expect(lock.packages['node_modules/@wordpress/scripts']?.version).toBe('34.2.0');
+    await expect(stat(path.join(output, 'node_modules'))).rejects.toThrow();
+
+    await execFileAsync('npm', ['ci', '--no-audit', '--no-fund'], { cwd: output });
+    await execFileAsync('npm', ['run', 'zip'], { cwd: output });
+    const archive = path.join(output, 'acme-notice.zip');
+    expect(await stat(archive)).toBeTruthy();
+    await execFileAsync('npm', ['run', 'test:zip', '--', archive], { cwd: output });
+
+    const { stdout } = await execFileAsync('unzip', ['-Z1', archive]);
+    expect(() => assertStandaloneZipEntries(stdout.split(/\r?\n/).filter(Boolean), 'notice', ['index.js'])).not.toThrow();
+  }, 300_000);
+});
+
+async function existingDirectPlugin(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'block-runner-plugin-'));
+  await writeFile(path.join(root, 'package.json'), JSON.stringify({
+    devDependencies: { '@wordpress/scripts': '34.2.0' },
+    scripts: { build: 'wp-scripts build --source-path=src/blocks --output-path=build/blocks' },
+  }, null, 2));
+  await writeFile(path.join(root, 'main.php'), `<?php\nadd_action( 'init', function() {\n\tregister_block_type( __DIR__ . '/build/blocks/existing' );\n} );\n`);
+  await writeSourceBlock(root, 'src/blocks/existing');
+  return root;
+}
+
+async function existingCollectionPlugin(bulk: boolean): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'block-runner-plugin-'));
+  await writeFile(path.join(root, 'package.json'), JSON.stringify({
+    devDependencies: { '@wordpress/scripts': '34.2.0' },
+    scripts: { build: 'wp-scripts build --source-path=src --output-path=build' },
+  }, null, 2));
+  const registration = bulk
+    ? `wp_register_block_metadata_collection( $build_dir, $manifest );\n\twp_register_block_types_from_metadata_collection( $build_dir );`
+    : `wp_register_block_metadata_collection( $build_dir, $manifest );\n\tregister_block_type_from_metadata_collection( $build_dir, 'acme/existing' );`;
+  await writeFile(path.join(root, 'plugin.php'), `<?php\nadd_action( 'init', function() {\n\t$build_dir = __DIR__ . '/build';\n\t$manifest = $build_dir . '/blocks-manifest.php';\n\t${registration}\n} );\n`);
+  await writeSourceBlock(root, 'src/blocks/existing');
+  return root;
+}
+
+async function writeSourceBlock(root: string, relative: string): Promise<void> {
+  const source = path.join(root, relative);
+  await mkdir(source, { recursive: true });
+  await writeFile(path.join(source, 'block.json'), JSON.stringify({ name: 'acme/existing' }));
+}


### PR DESCRIPTION
## Problem

A folder of block files is not build-ready until it matches the destination plugin's source root, build root, entry discovery and PHP registration strategy. Guessing those conventions can produce files that compile nowhere or modify an existing plugin too broadly. Closes #7.

## Solution

Support an explicit `@wordpress/scripts` host profile and a complete standalone-plugin fallback. Host inspection reports the roots, entry strategy and registration path, supports metadata collections, previews every touched file and rejects ambiguous layouts before writing. Positional entry points such as `wp-scripts build custom.js` are not accepted as metadata-discovery hosts.

## Testing and verification

Profile tests cover the supported metadata-collection and standalone paths and reject the unsupported positional-entry layout. The production font ZIP and second-block existing-plugin build pass without changing the first block. The public verification record is the [green CI run](https://github.com/humanmade/block-runner/actions/runs/33879578421) on Node 20, 22 and 24 with WordPress 7.1.

## Risk and rollout

Unknown hosts fail closed. Existing files are not replaced without a separate explicit decision, and standalone output remains available when the destination cannot be proven.
