### PR TITLE
Authoring workflow: make the shipped guide lead to a complete usable artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Block Runner ships a canonical skill in the open Agent Skills layout. Install it
 current project (ask the user before writing files):
 
 ```sh
-npx block-runner skill --install
+npx -y block-runner@testing skill --install
 ```
 
 That installs the same skill to the cross-agent `.agents/skills/block-runner` location and
@@ -71,13 +71,13 @@ default so the instructions can travel with a repository. Use user scope or one 
 that is what you want:
 
 ```sh
-npx block-runner skill --install --scope user
-npx block-runner skill --install --target agents
-npx block-runner skill --install --target claude
+npx -y block-runner@testing skill --install --scope user
+npx -y block-runner@testing skill --install --target agents
+npx -y block-runner@testing skill --install --target claude
 ```
 
 For a harness with another skills directory, use `--dir <skills-directory>`. With no skill
-system, `npx block-runner skill` prints the complete harness-neutral guide to stdout and writes
+system, `npx -y block-runner@testing skill` prints the complete harness-neutral guide to stdout and writes
 nothing. Project discovery is the most portable choice; user-wide discovery paths still vary
 between harnesses, so use `--dir` when a client documents a different global root.
 
@@ -162,7 +162,7 @@ Gutenberg before it reaches the editor.
 | `author <html> --json` | Analyze one authored design into a canonical registered-block plan, checked source, and style/asset ledgers. Does not write source. |
 | `assemble` | An intent tree — JSON describing which blocks and how they nest — to native blocks, built with `createBlock` so the result cannot be invalid. |
 | `author preview <plan\|->` | Validate and render a versioned registered-block AuthoringPlan without writing files. |
-| `author write <plan\|-> --confirm <hash> --output-dir <dir>` | Write only the reviewed plan bound to its SHA-256 confirmation and destination. |
+| `author write <plan\|-> --confirm <hash> --output-dir <dir>` | Write the reviewed compiler-owned source package bound to its SHA-256 confirmation and destination. Build and runtime proof remain separate. |
 | `validate` | Check block markup against headless Gutenberg. |
 | `fix` | Canonicalize near-miss block markup. |
 | `context` | Read a WordPress site into a `site.context.json` manifest (read-only). |
@@ -232,9 +232,60 @@ Missing, stale, or incorrect confirmation values write nothing. If a plan replac
 files, get a distinct, explicit replacement decision; a path collision, traversal or absolute
 path, changed destination, or any destination-prefix symlink fails before any write. The command
 rechecks these conditions immediately before exclusive, atomic writes. Use `-` for plan input
-only—never as a source of confirmation. Source generation is separate: this preview release writes only
-`files[].content` already contained in the confirmed plan, so a plan with descriptions alone is
-a successful no-op.
+only—never as a source of confirmation. `files` may declare only compiler-owned output paths and
+their `create`/`replace` operation; it never accepts file content. The deterministic compiler
+always emits its complete source set (and confirmed assets), including when `files` is empty.
+
+### Complete source-to-build routes
+
+Both routes begin with a reviewed `authoring-plan.json`; use `author <design.html> --name
+<namespace/slug> --json` when you need the deterministic HTML analysis to produce its canonical
+plan. Neither route requires hand-written React, PHP, block metadata, or a repair step.
+
+For a retained standalone plugin:
+
+```sh
+block-runner author preview authoring-plan.json --output-dir generated/feature-grid
+# Review the complete preview and obtain its displayed confirmation hash.
+block-runner author write authoring-plan.json --confirm '<confirmation-hash>' --output-dir generated/feature-grid
+
+block-runner plugin preview generated/feature-grid --standalone plugins/acme-feature-grid
+# Review the complete plugin preview and obtain its displayed fingerprint.
+block-runner plugin write generated/feature-grid --standalone plugins/acme-feature-grid --confirm '<plugin-fingerprint>'
+
+cd plugins/acme-feature-grid
+npm ci
+npm run zip
+npm run test:zip
+```
+
+`npm run zip` builds the compiler-generated source and creates
+`acme-feature-grid.zip`; `npm run test:zip` checks the archive policy. That is build-ready
+delivery, not WordPress runtime proof. Run `block-runner proof acme-feature-grid.zip --profile
+full ...` with the reviewed source, markup, and fixture before claiming activation or editor
+behaviour.
+
+For a recognised existing plugin, inspect before making any integration plan:
+
+```sh
+block-runner plugin inspect plugins/acme-host --json
+block-runner author preview authoring-plan.json --output-dir generated/feature-grid
+# Review and approve the displayed confirmation hash.
+block-runner author write authoring-plan.json --confirm '<confirmation-hash>' --output-dir generated/feature-grid
+
+block-runner plugin preview generated/feature-grid --host plugins/acme-host
+# Review the exact paths and separately approve every displayed replacement path.
+block-runner plugin write generated/feature-grid --host plugins/acme-host \
+  --confirm '<plugin-fingerprint>' --approve-replace '<approved-path>'
+
+cd plugins/acme-host
+npm run build
+```
+
+The recognised profile places the generated source and safe registration update into the host,
+then `npm run build` produces the previewed build target. Create the host's normal delivery ZIP
+and run the same `proof --profile full` route; source integration or a build alone is not a
+runtime verification.
 
 ### WordPress proof profiles
 
@@ -292,10 +343,10 @@ All commands:
 | `--wp-user <user>` | WordPress username for `rest` resolution. |
 | `--wp-app-password-env <name>` | Env var holding a WordPress application password. |
 
-`author` generates exactly one block package. It requires `--name <namespace/slug>` and writes
-to `--out-dir <path>` (or use `--json` to inspect the package without writing). Its `style.css`
-is registered with `block.json`'s `style` field, so parity-critical CSS loads in both editor and
-frontend; `editorStyle` is used only for explicitly supplied editor affordances.
+`author <html> --name <namespace/slug> --json` analyses exactly one design and returns a canonical
+plan; it does not write source. Use `author preview` then the confirmed `author write` command to
+materialize the compiler-owned package. Shared generated CSS is registered through `block.json`'s
+`style` field, while `editorStyle` is reserved for explicitly supplied editor affordances.
 
 `skill --install` adds installation flags:
 
@@ -308,8 +359,8 @@ frontend; `editorStyle` is used only for explicitly supplied editor affordances.
 | `--force` | Replace locally changed or unmanaged files at canonical bundle paths. |
 
 Installed instructions pin runtime commands to the package version that installed them, while
-their explicit update command stays on `@latest`. Re-run
-`npx block-runner@latest skill --install` to update them. Existing local edits are refused
+their explicit update command stays on `@testing` while authoring is testing-only. Re-run
+`npx -y block-runner@testing skill --install` to update them. Existing local edits are refused
 unless `--force` is explicit.
 
 An installation made by 0.7.x predates the managed manifest, so the first upgrade is

--- a/scripts/release-check.mjs
+++ b/scripts/release-check.mjs
@@ -253,7 +253,7 @@ function validateInstalledSkill(destination, bundle) {
   if (JSON.stringify(Object.keys(manifest.files ?? {}).sort()) !== JSON.stringify(names)) throw new Error('Installed skill manifest does not describe the packed bundle.');
   for (const name of names) {
     const bytes = readFileSync(path.join(bundle, name));
-    const expected = hash(name.endsWith('.md') ? bytes.toString('utf8').replace(/block-runner@latest(?!\s+skill\b)/g, `block-runner@${version}`) : bytes);
+    const expected = hash(name.endsWith('.md') ? bytes.toString('utf8').replace(/block-runner@(?:latest|testing)(?!\s+skill\b)/g, `block-runner@${version}`) : bytes);
     if (manifest.files[name].sha256 !== expected || hashFile(path.join(destination, name)) !== expected) {
       throw new Error(`Installed skill hash mismatch: ${name}`);
     }

--- a/skills/block-runner/references/GUIDE.md
+++ b/skills/block-runner/references/GUIDE.md
@@ -45,6 +45,11 @@ design and produces the versioned declarative **`AuthoringPlan`**; the determini
 generator produces all executable source and serializes blocks. This is deliberately different
 from converting a design into page `post_content`.
 
+This 0.9 authoring workflow is available from the testing channel. In this printed source guide,
+run its authoring, plugin, and proof commands with `npx -y block-runner@testing`. An installed
+skill rewrites runtime commands to the exact version that installed it, so its compiler and guide
+cannot drift. Do not substitute `@latest` while stable lacks `author`.
+
 ### The model's job: make the authoring plan, never the implementation
 
 The plan must state the target identity and **final** destination, native structure, field modes
@@ -63,9 +68,9 @@ owns the reviewable design decisions.
 ### `AuthoringPlan` v1 shape
 
 The CLI accepts exactly this versioned JSON shape. Object keys may be in any order; arrays retain
-their order and every listed value participates in the confirmation hash. `files` names the
-generated source outputs and uses only safe relative POSIX paths. The fields are required, though
-the arrays may be empty when a design genuinely has none of that item.
+their order and every listed value participates in the confirmation hash. `files` names
+compiler-owned source outputs and uses only safe relative POSIX paths. Core fields are required;
+list fields may be empty when a design genuinely has none of that item.
 
 | Field | Required shape |
 |---|---|
@@ -195,15 +200,16 @@ declaration-by-declaration accounting, including native mappings and explicit re
 ### Preview the exact plan before asking
 
 ```bash
-npx -y block-runner@latest author preview authoring-plan.json \
+npx -y block-runner@testing author preview authoring-plan.json \
   --output-dir <exact-final-destination>
 ```
 
-`author preview` writes no files. Before requesting consent, paste the literal plain-text
-terminal output verbatim. Do not replace the structure tree or the `Warnings` section with a
-prose summary. The user must see the full confirmation SHA-256, destination, destination
-fingerprint, tree, planned files, replacement markers, and warnings — including the `Warnings`
-section when it says `- none`, and `No files written.`
+`author preview` writes no files. Before requesting consent, lead with a compact plain-English
+summary of editability, unresolved decisions/losses, style and asset ownership, and destination
+changes. Then paste the literal plain-text terminal output verbatim. That summary supplements;
+it never replaces or truncates the structure tree, `Warnings` section, exact touched paths,
+replacement approvals, or full confirmation SHA-256. The user must see all of those details —
+including the `Warnings` section when it says `- none`, and `No files written.`
 
 Confirmation also binds the installed compiler template, which is shown in the preview.
 After upgrading Block Runner, request a fresh preview and approval; an old confirmation
@@ -220,25 +226,26 @@ non-interactive; it never obtains conversational consent for you.
 After that exact approval, run:
 
 ```bash
-npx -y block-runner@latest author write authoring-plan.json \
+npx -y block-runner@testing author write authoring-plan.json \
   --confirm '<full preview hash>' \
   --output-dir '<exact previewed destination>'
 ```
 
 Use the full hash and exact destination from the preview. If either changes, preview again and
 obtain fresh consent. Do not write into `mktemp`, an auto-deleted staging folder, or an
-unspecified location. A source package is incomplete until it lands in the requested existing
-plugin or retained standalone-plugin directory.
+unspecified location. The write report means **source delivered only**: it has not built,
+activated, registered, rendered, or proved the block. Follow its displayed `plugin preview`
+command for the existing-plugin or standalone boundary.
 
 ### Existing-plugin output
 
 Use this only after inspecting the target plugin. Do not guess its build or registration layout.
 
 ```bash
-npx -y block-runner@latest plugin inspect <plugin-root>
-npx -y block-runner@latest plugin preview <generated-block-dir> --host <plugin-root>
+npx -y block-runner@testing plugin inspect <plugin-root>
+npx -y block-runner@testing plugin preview <generated-block-dir> --host <plugin-root>
 # Show this complete preview, then obtain its displayed fingerprint and any separate replacement approvals.
-npx -y block-runner@latest plugin write <generated-block-dir> --host <plugin-root> \
+npx -y block-runner@testing plugin write <generated-block-dir> --host <plugin-root> \
   --confirm '<plugin preview fingerprint>' \
   --approve-replace '<each explicitly approved path>'
 ```
@@ -247,19 +254,39 @@ Write the generated block directly below the existing plugin's lasting source di
 temporary directory. If `plugin inspect` says the layout is unsupported, stop and offer
 standalone output rather than improvising registration or a build configuration.
 
+After that exact plugin write, source integration is delivered but no build or WordPress proof
+has run. The report's next command is the host build:
+
+```bash
+cd <plugin-root> && npm run build
+```
+
+That produces the reviewed build target reported by `plugin preview`. Create the host's normal
+installable ZIP after the build, then run the proof command below against that exact ZIP.
+
 ### Standalone-plugin output
 
 Use a retained, explicitly named plugin directory. Preview the wrapper before it is written,
 then build the final plugin archive from that same directory.
 
 ```bash
-npx -y block-runner@latest plugin preview <generated-block-dir> \
+npx -y block-runner@testing plugin preview <generated-block-dir> \
   --standalone <retained-plugin-directory>
 # Show this complete preview, then obtain its displayed fingerprint and any replacement approvals.
-npx -y block-runner@latest plugin write <generated-block-dir> \
+npx -y block-runner@testing plugin write <generated-block-dir> \
   --standalone <retained-plugin-directory> \
   --confirm '<plugin preview fingerprint>'
 ```
+
+After the exact write, the standalone source and its pinned lock are delivered; it is not built
+or runtime-proven. Run the reported next command without hand-authoring React or PHP:
+
+```bash
+cd <retained-plugin-directory> && npm ci && npm run zip && npm run test:zip
+```
+
+`npm run zip` runs the generated `wp-scripts` build and creates the plugin ZIP; `npm run
+test:zip` verifies its release contents. Those are build checks, not WordPress runtime proof.
 
 ### Proof is part of completion
 
@@ -267,7 +294,7 @@ Headless validation, source generation, or a successful build is not a full succ
 the final plugin ZIP and run a full proof against the exact reviewed input and generated package:
 
 ```bash
-npx -y block-runner@latest proof dist/acme-feature-grid.zip \
+npx -y block-runner@testing proof dist/acme-feature-grid.zip \
   --profile full \
   --input designs/feature-grid.html \
   --markup fixtures/feature-grid.blocks.html \
@@ -560,25 +587,25 @@ harmless. Read results from stdout or `--json`. Users who run this often can
 If your harness supports skills, install the canonical skill into the current project:
 
 ```bash
-npx -y block-runner@latest skill --install
+npx -y block-runner@testing skill --install
 ```
 
 That writes the same skill to the cross-agent `.agents/skills/block-runner` location and to
 Claude Code's `.claude/skills/block-runner` compatibility location. Narrow it when needed:
 
 ```bash
-npx -y block-runner@latest skill --install --target agents
-npx -y block-runner@latest skill --install --target claude
-npx -y block-runner@latest skill --install --scope user
-npx -y block-runner@latest skill --install --dir .another-agent/skills
-npx -y block-runner@latest skill --install --dry-run
+npx -y block-runner@testing skill --install --target agents
+npx -y block-runner@testing skill --install --target claude
+npx -y block-runner@testing skill --install --scope user
+npx -y block-runner@testing skill --install --dir .another-agent/skills
+npx -y block-runner@testing skill --install --dry-run
 ```
 
 Project discovery is the most portable choice. User-wide discovery paths still vary between
 harnesses, so use `--dir` when a client documents a different global skills root.
 The installer pins runtime examples to its own package version so the guide and CLI contract
-stay aligned. To update later, rerun `npx -y block-runner@latest skill --install`.
+stay aligned. To update later, rerun `npx -y block-runner@testing skill --install`.
 
 **Ask the user first.** This writes files into their project, which is their call, not yours.
 If they decline, or their harness has no skill system, nothing is lost — reading this guide is
-the same information. `npx -y block-runner@latest skill` prints it without installing anything.
+the same information. `npx -y block-runner@testing skill` prints it without installing anything.

--- a/src/authoring/preview.ts
+++ b/src/authoring/preview.ts
@@ -81,7 +81,9 @@ export function renderAuthoringPreview(plan: AuthoringPlan, options: AuthoringPr
   addKeyValue(lines, 'Text domain', target.textDomain ?? target.textdomain, width);
   addKeyValue(lines, 'WordPress', target.wordpress, width);
   const destination = options.destination ?? readString(target, ['directory', 'destination', 'outputDir']);
-  addKeyValue(lines, 'Destination', destination, width);
+  // The exact destination is part of the confirmation boundary, so it must remain copyable
+  // even when a narrow terminal would otherwise split it across lines.
+  addExactKeyValue(lines, 'Destination', destination);
   addKeyValue(lines, 'Destination fingerprint', options.destinationFingerprint, width);
 
   section(lines, 'Structure', width);
@@ -176,7 +178,7 @@ export function renderAuthoringPreview(plan: AuthoringPlan, options: AuthoringPr
     if (options.touchedFiles.length === 0) {
       bullet(lines, 'none', width);
     } else {
-      options.touchedFiles.forEach((file) => bullet(lines, describeTouchedFile(file), width));
+      options.touchedFiles.forEach((file) => renderTouchedFile(lines, file, width));
     }
   }
 
@@ -275,7 +277,7 @@ function renderReviewSummary(
   if (destination || touchedFiles.length > 0) {
     bullet(
       lines,
-      `Destination changes: ${destination ?? 'destination not supplied'}; ${creates} create, ${replacements} replacement${replacements === 1 ? '' : 's'}${replacements ? ' requiring explicit hash-bound approval' : ''}. Exact paths follow below.`,
+      `Destination changes: ${destination ? 'selected destination' : 'destination not supplied'}; ${creates} create, ${replacements} replacement${replacements === 1 ? '' : 's'}${replacements ? ' requiring explicit hash-bound approval' : ''}. Exact paths follow below.`,
       width,
     );
   }
@@ -514,11 +516,16 @@ function describeFile(value: unknown, index: number): string {
   return `${path}${kind ? ` [${kind}]` : ''} [${replacement}]`;
 }
 
+function renderTouchedFile(lines: string[], file: AuthoringPreviewTouchedFile, width: number): void {
+  addExactKeyValue(lines, file.operation === 'replace' ? 'Replacement path' : 'Create path', file.path);
+  bullet(lines, describeTouchedFile(file), width);
+}
+
 function describeTouchedFile(file: AuthoringPreviewTouchedFile): string {
   if (file.operation === 'replace') {
-    return `${file.path} [replace; ${file.exists ? 'existing file' : 'path currently absent'}; explicit hash-bound replacement approval required]`;
+    return `[replace; ${file.exists ? 'existing file' : 'path currently absent'}; explicit hash-bound replacement approval required]`;
   }
-  return `${file.path} [create; ${file.exists ? 'conflict: existing file' : 'path currently absent'}]`;
+  return `[create; ${file.exists ? 'conflict: existing file' : 'path currently absent'}]`;
 }
 
 function describeItem(value: unknown, index: number): string {

--- a/src/authoring/preview.ts
+++ b/src/authoring/preview.ts
@@ -14,6 +14,18 @@ export interface AuthoringPreviewContext {
   destination?: string;
   /** Opaque fingerprint of the destination observed while previewing. */
   destinationFingerprint?: string;
+  /** Exact destination paths inspected for this preview. */
+  touchedFiles?: ReadonlyArray<AuthoringPreviewTouchedFile>;
+}
+
+/** A destination-bound output change shown before the confirmation hash. */
+export interface AuthoringPreviewTouchedFile {
+  /** Absolute path inspected by the preview. */
+  path: string;
+  /** The hash-bound operation selected for this compiler-owned output. */
+  operation: 'create' | 'replace';
+  /** Whether this exact path existed as a regular file during inspection. */
+  exists?: boolean;
 }
 
 export interface AuthoringPreviewOptions extends AuthoringPreviewContext {
@@ -43,11 +55,12 @@ export function renderAuthoringPreview(plan: AuthoringPlan, options: AuthoringPr
   const lines: string[] = [];
 
   heading(lines, 'Authoring plan preview', width, '=');
+  renderReviewSummary(lines, value, options, width);
+
+  section(lines, 'Plan identity', width);
   addKeyValue(lines, 'Plan version', value.version, width);
   addKeyValue(lines, 'Generator version', value.generatorVersion, width);
   addKeyValue(lines, 'Compiler template', REGISTERED_BLOCK_TEMPLATE_VERSION, width);
-  addKeyValue(lines, 'Plan SHA-256', options.hash ?? hashAuthoringPlan(plan), width);
-  addKeyValue(lines, 'Confirmation SHA-256', options.confirmationHash, width);
 
   const source = asRecord(value.source);
   if (Object.keys(source).length > 0) {
@@ -158,12 +171,35 @@ export function renderAuthoringPreview(plan: AuthoringPlan, options: AuthoringPr
     files.forEach((file, index) => bullet(lines, describeFile(file, index), width));
   }
 
+  if (options.touchedFiles) {
+    section(lines, 'Destination changes', width);
+    if (options.touchedFiles.length === 0) {
+      bullet(lines, 'none', width);
+    } else {
+      options.touchedFiles.forEach((file) => bullet(lines, describeTouchedFile(file), width));
+    }
+  }
+
   section(lines, 'Warnings', width);
   const warnings = asArray(value.warnings);
   if (warnings.length === 0) {
     bullet(lines, 'none', width);
   } else {
     warnings.forEach((warning) => bullet(lines, plain(warning), width));
+  }
+
+  section(lines, 'Confirmation', width);
+  // These values deliberately come after every authoritative tree, warning, decision, and
+  // destination change. A compact summary helps a human orient themselves; it never replaces
+  // the detail that the confirmation actually binds.
+  const planHash = options.hash ?? hashAuthoringPlan(plan);
+  if (options.confirmationHash) {
+    // A confirmation is a copy-and-paste token. Keep each complete hash on one literal line
+    // instead of wrapping it at the terminal width and making a reviewed value ambiguous.
+    addExactKeyValue(lines, 'Plan SHA-256', planHash);
+    addExactKeyValue(lines, 'Confirmation SHA-256', options.confirmationHash);
+  } else {
+    addKeyValue(lines, 'Plan SHA-256', planHash, width);
   }
 
   section(lines, 'Write status', width);
@@ -174,6 +210,110 @@ export function renderAuthoringPreview(plan: AuthoringPlan, options: AuthoringPr
 
 /** Alias kept concise for programmatic consumers. */
 export const previewAuthoringPlan = renderAuthoringPreview;
+
+function renderReviewSummary(
+  lines: string[],
+  value: RecordValue,
+  options: AuthoringPreviewOptions,
+  width: number,
+): void {
+  section(lines, 'Review summary', width);
+  const fields = asArray(value.fields).map(asRecord);
+  const modes = new Map<'fixed' | 'editable' | 'override', number>([
+    ['fixed', 0], ['editable', 0], ['override', 0],
+  ]);
+  fields.forEach((field) => modes.set(fieldMode(field), (modes.get(fieldMode(field)) ?? 0) + 1));
+  bullet(
+    lines,
+    `Editing: ${modes.get('fixed')} fixed, ${modes.get('editable')} editable, ${modes.get('override')} override field${fields.length === 1 ? '' : 's'}.`,
+    width,
+  );
+
+  const styles = asRecord(value.styles);
+  const coverage = asRecord(value.coverage);
+  const droppedStyles = asArray(styles.outcomes).filter((outcome) => readString(asRecord(outcome), ['outcome']) === 'dropped').length;
+  const blockedCoverageStyles = asArray(coverage.styles).filter((style) => {
+    const outcome = readString(asRecord(style), ['outcome']);
+    return outcome === 'warned' || outcome === 'blocked';
+  }).length;
+  const unresolvedCoverageAssets = asArray(coverage.assets).filter((asset) => {
+    const outcome = readString(asRecord(asset), ['outcome']);
+    return outcome === 'unresolved' || outcome === 'blocked';
+  }).length;
+  const missingPlanAssets = asArray(value.assets).filter((asset) => readString(asRecord(asset), ['status']) === 'missing').length;
+  const warnings = asArray(value.warnings).length;
+  const unresolved = droppedStyles + blockedCoverageStyles + unresolvedCoverageAssets + missingPlanAssets;
+  bullet(
+    lines,
+    unresolved || warnings
+      ? `Unresolved decisions and losses: ${unresolved} style or asset issue${unresolved === 1 ? '' : 's'}; ${warnings} warning${warnings === 1 ? '' : 's'}.`
+      : 'Unresolved decisions and losses: none; no warnings.',
+    width,
+  );
+
+  const assets = asArray(value.assets).map(asRecord);
+  const ownedAssets = assets.filter((asset) => readString(asset, ['status']) === 'ready' || readString(asset, ['destination']) !== undefined);
+  const externalAssets = assets.filter((asset) => readString(asset, ['status']) === 'external');
+  const licensedFonts = ownedAssets.filter((asset) => readString(asset, ['kind']) === 'font' && Object.keys(asRecord(asset.fontLicense)).length > 0);
+  bullet(
+    lines,
+    `Asset ownership: ${ownedAssets.length} package-owned, ${externalAssets.length} external, ${licensedFonts.length} licensed bundled font${licensedFonts.length === 1 ? '' : 's'}.`,
+    width,
+  );
+
+  const styleOwnership = styleOwnershipSummary(styles, coverage);
+  bullet(
+    lines,
+    `Style ownership: ${styleOwnership.native} native-owned, ${styleOwnership.shared} package-owned shared, ${styleOwnership.editor} editor-only.`,
+    width,
+  );
+
+  const touchedFiles = options.touchedFiles ?? [];
+  const creates = touchedFiles.filter((file) => file.operation === 'create').length;
+  const replacements = touchedFiles.filter((file) => file.operation === 'replace').length;
+  const destination = options.destination ?? readString(asRecord(value.target), ['directory', 'destination', 'outputDir']);
+  if (destination || touchedFiles.length > 0) {
+    bullet(
+      lines,
+      `Destination changes: ${destination ?? 'destination not supplied'}; ${creates} create, ${replacements} replacement${replacements === 1 ? '' : 's'}${replacements ? ' requiring explicit hash-bound approval' : ''}. Exact paths follow below.`,
+      width,
+    );
+  }
+}
+
+function styleOwnershipSummary(styles: RecordValue, coverage: RecordValue): {
+  native: number;
+  shared: number;
+  editor: number;
+} {
+  const ledger = asArray(coverage.styles).map(asRecord);
+  if (ledger.length > 0) {
+    return {
+      native: ledger.filter((style) => readString(style, ['scope']) === 'shared'
+        && ['native', 'preset', 'literal'].includes(readString(style, ['outcome']) ?? '')).length,
+      shared: ledger.filter((style) => readString(style, ['scope']) === 'shared'
+        && readString(style, ['outcome']) === 'scoped-css').length,
+      editor: ledger.filter((style) => readString(style, ['scope']) === 'editor'
+        && readString(style, ['outcome']) === 'scoped-css').length,
+    };
+  }
+
+  const outcomes = asArray(styles.outcomes).map(asRecord);
+  return {
+    native: outcomes.filter((outcome) => ['native', 'token'].includes(readString(outcome, ['outcome']) ?? '')).length,
+    shared: outcomes.filter((outcome) => readString(outcome, ['outcome']) === 'scoped-css').length
+      + cssDeclarationCount(asArray(styles.rules)),
+    editor: cssDeclarationCount(asArray(styles.editorRules)),
+  };
+}
+
+function cssDeclarationCount(rules: unknown[]): number {
+  return rules.reduce<number>((count, input) => {
+    const rule = asRecord(input);
+    if (rule.kind === 'conditional') return count + cssDeclarationCount(asArray(rule.rules));
+    return count + asArray(rule.declarations).length;
+  }, 0);
+}
 
 function renderCssRules(lines: string[], rules: unknown[], width: number, prefix = ''): void {
   for (const input of rules) {
@@ -374,6 +514,13 @@ function describeFile(value: unknown, index: number): string {
   return `${path}${kind ? ` [${kind}]` : ''} [${replacement}]`;
 }
 
+function describeTouchedFile(file: AuthoringPreviewTouchedFile): string {
+  if (file.operation === 'replace') {
+    return `${file.path} [replace; ${file.exists ? 'existing file' : 'path currently absent'}; explicit hash-bound replacement approval required]`;
+  }
+  return `${file.path} [create; ${file.exists ? 'conflict: existing file' : 'path currently absent'}]`;
+}
+
 function describeItem(value: unknown, index: number): string {
   if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
     return plain(value);
@@ -416,6 +563,13 @@ function addKeyValue(lines: string[], key: string, value: unknown, width: number
     return;
   }
   wrapped(lines, `${key}: ${describeScalar(value)}`, width, '  ');
+}
+
+function addExactKeyValue(lines: string[], key: string, value: unknown): void {
+  if (value === undefined || value === null || value === '') {
+    return;
+  }
+  lines.push(`${key}: ${plain(value)}`);
 }
 
 function bullet(lines: string[], value: string, width: number): void {

--- a/src/authoring/schema.ts
+++ b/src/authoring/schema.ts
@@ -220,15 +220,15 @@ export interface AuthoringAsset {
 }
 
 /**
- * A prospective generated file. Source generation is intentionally outside the preview: `content`
- * is therefore optional, but when supplied it is hash-bound just like every other plan decision.
+ * A prospective generated file for low-level destination writers. The registered-block compiler
+ * deliberately rejects `content`: declarative AuthoringPlans may only select its own output paths.
  */
 export interface AuthoringFile {
   /** Portable, relative POSIX path below the output directory. */
   path: string;
   kind?: string;
   content?: string;
-  /** Replacing a collision requires this separate explicit, hash-bound plan decision. */
+  /** Replacing a collision requires this separate, hash-bound approval decision. */
   operation?: AuthoringFileOperation;
 }
 
@@ -236,8 +236,8 @@ export interface AuthoringFile {
  * A complete, declarative input to registered-block authoring.
  *
  * The contract keeps human decisions separate from generated source: the structure and editor
- * model are explicit, while files describe intended outputs and may carry materialized content
- * only when another deterministic producer supplied it.
+ * model are explicit, while registered-block compilation treats files as compiler-owned output
+ * paths and collision policy rather than executable source.
  */
 export interface AuthoringPlan {
   version: typeof AUTHORING_PLAN_VERSION;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -357,7 +357,7 @@ plugin
 
 plugin
   .command('write <blockDirectory>')
-  .description('Write exactly a previewed plugin plan after its fingerprint and replacement approvals are supplied.')
+  .description('Write exactly a previewed plugin source plan; build and runtime proof remain separate.')
   .requiredOption('--confirm <fingerprint>', 'exact fingerprint printed by plugin preview')
   .option('--host <directory>', 'recognised existing wp-scripts plugin root')
   .option('--standalone <directory>', 'write a complete standalone plugin wrapper instead')
@@ -369,12 +369,15 @@ plugin
       throw new Error('plugin confirmation does not match the reviewed preview; no files written');
     }
     const result = await writePluginOutput(plan, { authorizedReplacements: options.approveReplace });
+    const delivery = pluginDelivery(plan.mode, result.directory);
     if (options.json) {
-      console.log(JSON.stringify({ ok: true, ...result }, null, 2));
+      console.log(JSON.stringify({ ok: true, ...result, delivery }, null, 2));
       return;
     }
     console.log(`plugin write: ${result.written.length} file${result.written.length === 1 ? '' : 's'} written to ${result.directory}`);
     for (const file of result.written) console.log(`- ${file}`);
+    console.log('Source delivery: complete. Build and WordPress runtime proof have not run.');
+    console.log(`Next: ${delivery.nextCommand}`);
   });
 
 program
@@ -466,7 +469,7 @@ program
 
 author
   .command('preview <planOrStdin>')
-  .description('Validate and render an authoring plan without writing files.')
+  .description('Validate and review a declarative authoring plan without writing files.')
   .option('--output-dir <dir>', 'exact destination directory to fingerprint (default: plan directory or current directory)')
   .option('--width <columns>', 'preview width in terminal columns')
   .option('--json', 'emit a machine-readable preview')
@@ -477,6 +480,7 @@ author
     const destination = authoringDestination(options.outputDir, plan.target.directory);
     const inspection = await inspectAuthoringDestination(destination, outputPlan);
     const confirmation = hashAuthoringConfirmation(plan, inspection);
+    const touchedFiles = previewTouchedFiles(inspection, outputPlan.files);
     const width = parsePreviewWidth(options.width);
     const preview = renderAuthoringPreview({ ...plan, files: outputPlan.files.map((file) => ({ ...file })) }, {
       hash,
@@ -487,6 +491,7 @@ author
       color: !process.env.NO_COLOR,
       destination: inspection.directory,
       destinationFingerprint: inspection.fingerprint,
+      touchedFiles,
     });
     const result = {
       ok: true,
@@ -499,6 +504,8 @@ author
       canonicalJson: serializeAuthoringPlan(plan),
       plan,
       destination: { directory: inspection.directory, fingerprint: inspection.fingerprint },
+      touchedFiles,
+      replacementApprovals: touchedFiles.filter((file) => file.operation === 'replace').map((file) => file.path),
       preview,
       noFilesWritten: true,
     };
@@ -511,7 +518,7 @@ author
 
 author
   .command('write <planOrStdin>')
-  .description('Generate and write a sealed registered-block package from a confirmed authoring plan.')
+  .description('Generate and write a sealed registered-block source package; build and runtime proof remain separate.')
   .requiredOption('--confirm <hash>', 'exact destination-bound SHA-256 from author preview')
   .requiredOption('--output-dir <dir>', 'exact destination directory')
   .option('--json', 'emit a machine-readable write result')
@@ -535,6 +542,7 @@ author
       throw new Error('generated registered-block package does not match the confirmed plan; no files written');
     }
     const result = await writeGeneratedRegisteredBlock(destination, generated, inspection);
+    const delivery = authoringDelivery(result.directory);
     const output = {
       ok: true,
       command: 'author write',
@@ -543,6 +551,7 @@ author
       destination: { directory: result.directory, fingerprint: result.fingerprint },
       written: result.written,
       noFilesWritten: result.written.length === 0,
+      delivery,
     };
     if (options.json) {
       console.log(JSON.stringify(output, null, 2));
@@ -559,6 +568,9 @@ author
     for (const file of result.written) {
       console.log(`Wrote: ${file}`);
     }
+    console.log('Source delivery: complete. Build and WordPress runtime proof have not run.');
+    console.log(`Next (existing plugin): ${delivery.next.existingPlugin}`);
+    console.log(`Next (standalone plugin): ${delivery.next.standalonePlugin}`);
   });
 
 async function main(): Promise<void> {
@@ -712,6 +724,61 @@ function authoringDestination(outputDirectory: string | undefined, packageDirect
   return packageDirectory && packageDirectory !== '.'
     ? path.resolve(process.cwd(), ...packageDirectory.split('/'))
     : path.resolve(process.cwd());
+}
+
+function previewTouchedFiles(
+  inspection: Awaited<ReturnType<typeof inspectAuthoringDestination>>,
+  files: ReadonlyArray<{ path: string; operation: 'create' | 'replace' }>,
+): Array<{ path: string; operation: 'create' | 'replace'; exists: boolean }> {
+  return files.map((file) => {
+    const target = path.resolve(inspection.directory, ...file.path.split('/'));
+    return {
+      path: target,
+      operation: file.operation,
+      exists: inspection.entries.some((entry) => entry.path === target && entry.kind === 'file'),
+    };
+  });
+}
+
+function authoringDelivery(directory: string): {
+  status: 'source-delivered';
+  buildRuntimeProof: 'not-run';
+  next: { existingPlugin: string; standalonePlugin: string };
+} {
+  const runtime = pinnedBlockRunnerRuntime();
+  return {
+    status: 'source-delivered',
+    buildRuntimeProof: 'not-run',
+    next: {
+      existingPlugin: `${runtime} plugin preview ${shellDisplay(directory)} --host <existing-plugin-root>`,
+      standalonePlugin: `${runtime} plugin preview ${shellDisplay(directory)} --standalone <retained-plugin-directory>`,
+    },
+  };
+}
+
+function pluginDelivery(mode: 'existing' | 'standalone', directory: string): {
+  status: 'source-delivered';
+  buildRuntimeProof: 'not-run';
+  nextCommand: string;
+} {
+  return {
+    status: 'source-delivered',
+    buildRuntimeProof: 'not-run',
+    nextCommand: mode === 'standalone'
+      ? `cd ${shellDisplay(directory)} && npm ci && npm run zip && npm run test:zip`
+      : `cd ${shellDisplay(directory)} && npm run build`,
+  };
+}
+
+function shellDisplay(value: string): string {
+  // These strings are explicitly offered as the next command to run. JSON quoting is not shell
+  // quoting: a double-quoted `$()` or backtick still executes. Single-quote every argument and
+  // reopen around literal single quotes, which is safe in POSIX-compatible shells.
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function pinnedBlockRunnerRuntime(): string {
+  return `npx -y block-runner@${packageVersion}`;
 }
 
 function parsePreviewWidth(value: string | undefined): number | undefined {
@@ -876,7 +943,7 @@ async function pluginPlanForCli(
     return await planExistingPluginOutput(options.host!, generated);
   } catch (error) {
     if (error instanceof UnsupportedPluginLayoutError) {
-      throw new Error(`${error.message} Offer: plugin preview ${JSON.stringify(blockDirectory)} --standalone <output-dir>.`);
+      throw new Error(`${error.message} Offer: ${pinnedBlockRunnerRuntime()} plugin preview ${shellDisplay(blockDirectory)} --standalone <output-dir>.`);
     }
     throw error;
   }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -264,7 +264,7 @@ function pinPackageVersion(file: BundleFile, packageVersion: string): Buffer {
   }
   return Buffer.from(
     file.content.toString('utf8').replace(
-      /block-runner@latest(?!\s+skill\b)/g,
+      /block-runner@(?:latest|testing)(?!\s+skill\b)/g,
       `block-runner@${packageVersion}`,
     ),
   );

--- a/test/authoring.cli.test.ts
+++ b/test/authoring.cli.test.ts
@@ -1,11 +1,13 @@
 import { spawn } from 'node:child_process';
 import { mkdir, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { hashAuthoringPlan } from '../src/authoring/schema.js';
 
 const tsxImport = import.meta.resolve('tsx');
+const { version: packageVersion } = createRequire(import.meta.url)('../package.json') as { version: string };
 
 function plan(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -71,10 +73,28 @@ describe('author CLI', () => {
       project,
     );
     expect(written.code).toBe(0);
-    expect(JSON.parse(written.stdout)).toMatchObject({
+    const result = JSON.parse(written.stdout) as {
+      destination: { directory: string };
+      delivery: { next: { existingPlugin: string; standalonePlugin: string } };
+    };
+    expect(result).toMatchObject({
       written: ['block.json', 'index.js', 'edit.js', 'save.js', 'style.scss', 'editor.scss', 'block.php'],
       noFilesWritten: false,
+      delivery: {
+        status: 'source-delivered',
+        buildRuntimeProof: 'not-run',
+        next: {
+          existingPlugin: expect.stringContaining('plugin preview'),
+          standalonePlugin: expect.stringContaining('plugin preview'),
+        },
+      },
     });
+    expect(result.delivery.next.existingPlugin).toBe(
+      `npx -y block-runner@${packageVersion} plugin preview ${shellQuote(result.destination.directory)} --host <existing-plugin-root>`,
+    );
+    expect(result.delivery.next.standalonePlugin).toBe(
+      `npx -y block-runner@${packageVersion} plugin preview ${shellQuote(result.destination.directory)} --standalone <retained-plugin-directory>`,
+    );
     expect(JSON.parse(await readFile(path.join(project, 'generated', 'block.json'), 'utf8'))).toMatchObject({
       name: 'example/notice',
       title: 'Notice',
@@ -92,7 +112,19 @@ describe('author CLI', () => {
 
     const preview = await runCli(['author', 'preview', 'plan.json', '--output-dir', 'generated', '--json'], project);
     expect(preview.code).toBe(0);
-    const previewJson = JSON.parse(preview.stdout) as { hash: string };
+    const previewJson = JSON.parse(preview.stdout) as {
+      hash: string;
+      preview: string;
+      touchedFiles: Array<{ path: string; operation: string; exists: boolean }>;
+      replacementApprovals: string[];
+    };
+    const replacement = previewJson.touchedFiles.find((file) => file.operation === 'replace');
+    expect(replacement).toMatchObject({ path: expect.stringMatching(/\/generated\/block\.json$/), exists: true });
+    expect(previewJson.replacementApprovals).toEqual([replacement!.path]);
+    expect(previewJson.preview).toContain(replacement!.path);
+    expect(previewJson.preview).toContain('explicit hash-bound replacement approval required');
+    expect(previewJson.preview).toContain(`Confirmation SHA-256: ${previewJson.hash}`);
+    expect(previewJson.preview.indexOf('Warnings')).toBeLessThan(previewJson.preview.indexOf('Confirmation SHA-256:'));
     await writeFile(path.join(destination, 'block.json'), 'changed after preview\n');
 
     const result = await runCli(
@@ -114,7 +146,56 @@ describe('author CLI', () => {
     expect(result.code).toBe(2);
     await expect(stat(path.join(project, 'generated'))).rejects.toMatchObject({ code: 'ENOENT' });
   });
+
+  it('reports source delivery and its next integration commands without claiming proof', async () => {
+    const project = await mkdtemp(path.join(tmpdir(), 'block-runner-author-cli-'));
+    await writeFile(path.join(project, 'plan.json'), JSON.stringify(plan()));
+    const preview = await runCli(['author', 'preview', 'plan.json', '--output-dir', 'generated', '--json'], project);
+    const previewJson = JSON.parse(preview.stdout) as { hash: string; destination: { directory: string } };
+
+    const written = await runCli(
+      ['author', 'write', 'plan.json', '--confirm', previewJson.hash, '--output-dir', 'generated'],
+      project,
+    );
+
+    expect(written.code).toBe(0);
+    expect(written.stdout).toContain('Source delivery: complete. Build and WordPress runtime proof have not run.');
+    expect(written.stdout).toContain(
+      `Next (existing plugin): npx -y block-runner@${packageVersion} plugin preview ${shellQuote(previewJson.destination.directory)} --host <existing-plugin-root>`,
+    );
+    expect(written.stdout).toContain(
+      `Next (standalone plugin): npx -y block-runner@${packageVersion} plugin preview ${shellQuote(previewJson.destination.directory)} --standalone <retained-plugin-directory>`,
+    );
+  });
+
+  it('quotes shell metacharacters in JSON next commands', async () => {
+    const project = await mkdtemp(path.join(tmpdir(), 'block-runner-author-cli-'));
+    const outputDirectory = "generated;$(printf unsafe)`&| ' space";
+    await writeFile(path.join(project, 'plan.json'), JSON.stringify(plan()));
+    const preview = await runCli(['author', 'preview', 'plan.json', '--output-dir', outputDirectory, '--json'], project);
+    const previewJson = JSON.parse(preview.stdout) as { hash: string };
+    const written = await runCli(
+      ['author', 'write', 'plan.json', '--confirm', previewJson.hash, '--output-dir', outputDirectory, '--json'],
+      project,
+    );
+
+    expect(written.code).toBe(0);
+    const result = JSON.parse(written.stdout) as {
+      destination: { directory: string };
+      delivery: { next: { existingPlugin: string; standalonePlugin: string } };
+    };
+    expect(result.delivery.next.existingPlugin).toBe(
+      `npx -y block-runner@${packageVersion} plugin preview ${shellQuote(result.destination.directory)} --host <existing-plugin-root>`,
+    );
+    expect(result.delivery.next.standalonePlugin).toBe(
+      `npx -y block-runner@${packageVersion} plugin preview ${shellQuote(result.destination.directory)} --standalone <retained-plugin-directory>`,
+    );
+  });
 });
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
 
 function runCli(args: string[], cwd: string): Promise<{ code: number | null; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {

--- a/test/authoring.preview.test.ts
+++ b/test/authoring.preview.test.ts
@@ -91,6 +91,49 @@ describe('authoring preview', () => {
     }
   });
 
+  it('leads with a compact review summary while retaining every approval detail before the hash', () => {
+    const reviewed = validateAuthoringPlan({
+      ...plan,
+      styles: {
+        ...plan.styles,
+        outcomes: [...plan.styles.outcomes, { property: 'filter', outcome: 'dropped', reason: 'Unsupported.' }],
+      },
+      coverage: {
+        ...plan.coverage!,
+        styles: [...plan.coverage!.styles,
+          { property: 'display', value: 'grid', outcome: 'scoped-css', scope: 'shared', atRules: [] },
+          { property: 'outline', value: '2px solid blue', outcome: 'scoped-css', scope: 'editor', atRules: [] },
+          { property: 'position', value: 'fixed', outcome: 'blocked', scope: 'shared', atRules: [] },
+        ],
+        assets: [...plan.coverage!.assets, {
+          reference: 'remote.png', kind: 'image', outcome: 'unresolved', reason: 'No approved asset.',
+        }],
+      },
+    });
+    const confirmation = 'e'.repeat(64);
+    const output = renderAuthoringPreview(reviewed, {
+      width: 160,
+      destination: '/work/generated/feature-grid',
+      touchedFiles: [
+        { path: '/work/generated/feature-grid/block.json', operation: 'create', exists: false },
+        { path: '/work/generated/feature-grid/edit.js', operation: 'replace', exists: true },
+      ],
+      confirmationHash: confirmation,
+    });
+
+    expect(output).toContain('Review summary');
+    expect(output).toContain('Editing: 1 fixed, 1 editable, 1 override fields.');
+    expect(output).toContain('Unresolved decisions and losses: 3 style or asset issues; 1 warning.');
+    expect(output).toContain('Asset ownership: 1 package-owned, 0 external, 0 licensed bundled fonts.');
+    expect(output).toContain('Style ownership: 1 native-owned, 1 package-owned shared, 1 editor-only.');
+    expect(output).toContain('/work/generated/feature-grid/block.json [create; path currently absent]');
+    expect(output).toContain('/work/generated/feature-grid/edit.js [replace; existing file; explicit hash-bound replacement approval required]');
+    expect(output).toContain(`Confirmation SHA-256: ${confirmation}`);
+    expect(output.indexOf('Review summary')).toBeLessThan(output.indexOf('Structure'));
+    expect(output.indexOf('Structure')).toBeLessThan(output.indexOf('Warnings'));
+    expect(output.indexOf('Warnings')).toBeLessThan(output.indexOf(`Confirmation SHA-256: ${confirmation}`));
+  });
+
   it('shows the asset binding and license record for a confirmed font face', () => {
     const fontPlan = validateAuthoringPlan({
       ...plan,

--- a/test/authoring.preview.test.ts
+++ b/test/authoring.preview.test.ts
@@ -87,7 +87,8 @@ describe('authoring preview', () => {
   it('wraps to the supplied terminal width', () => {
     for (const width of [44, 12]) {
       const output = renderAuthoringPreview(plan, { width });
-      expect(output.split('\n').every((line) => line.length <= width)).toBe(true);
+      const exactDestination = `Destination: ${plan.target.directory}`;
+      expect(output.split('\n').every((line) => line.length <= width || line === exactDestination)).toBe(true);
     }
   });
 
@@ -126,12 +127,33 @@ describe('authoring preview', () => {
     expect(output).toContain('Unresolved decisions and losses: 3 style or asset issues; 1 warning.');
     expect(output).toContain('Asset ownership: 1 package-owned, 0 external, 0 licensed bundled fonts.');
     expect(output).toContain('Style ownership: 1 native-owned, 1 package-owned shared, 1 editor-only.');
-    expect(output).toContain('/work/generated/feature-grid/block.json [create; path currently absent]');
-    expect(output).toContain('/work/generated/feature-grid/edit.js [replace; existing file; explicit hash-bound replacement approval required]');
+    expect(output).toContain('Destination: /work/generated/feature-grid');
+    expect(output).toContain('Create path: /work/generated/feature-grid/block.json');
+    expect(output).toContain('Replacement path: /work/generated/feature-grid/edit.js');
+    expect(output).toContain('[replace; existing file; explicit hash-bound replacement approval required]');
     expect(output).toContain(`Confirmation SHA-256: ${confirmation}`);
     expect(output.indexOf('Review summary')).toBeLessThan(output.indexOf('Structure'));
     expect(output.indexOf('Structure')).toBeLessThan(output.indexOf('Warnings'));
     expect(output.indexOf('Warnings')).toBeLessThan(output.indexOf(`Confirmation SHA-256: ${confirmation}`));
+  });
+
+  it('keeps authoritative destination and replacement paths copyable at narrow widths', () => {
+    const width = 24;
+    const destination = '/workspace/deterministic-authoring-preview/with/a-deliberately-long-destination';
+    const replacement = `${destination}/block.json`;
+    const output = renderAuthoringPreview(plan, {
+      width,
+      destination,
+      touchedFiles: [{ path: replacement, operation: 'replace', exists: true }],
+    });
+    const lines = output.split('\n');
+
+    expect(destination.length).toBeGreaterThan(width);
+    expect(replacement.length).toBeGreaterThan(width);
+    expect(lines).toContain(`Destination: ${destination}`);
+    expect(lines).toContain(`Replacement path: ${replacement}`);
+    const copyableLines = new Set([`Destination: ${destination}`, `Replacement path: ${replacement}`]);
+    expect(lines.filter((line) => !copyableLines.has(line)).every((line) => line.length <= width)).toBe(true);
   });
 
   it('shows the asset binding and license record for a confirmed font face', () => {

--- a/test/authoring.schema.test.ts
+++ b/test/authoring.schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { hashAuthoringPlan, serializeAuthoringPlan, validateAuthoringPlan } from '../src/authoring/schema.js';
+import { compileRegisteredBlock } from '../src/authoring/generate.js';
 
 function plan(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -46,6 +47,14 @@ describe('AuthoringPlan schema', () => {
       expect(() => validateAuthoringPlan(plan({ files: [{ path: file }] }))).toThrow(/safe relative path/);
     }
     expect(() => validateAuthoringPlan(plan({ files: [{ path: 'src' }, { path: 'src/edit.ts' }] }))).toThrow(/descendant/);
+  });
+
+  it('keeps executable source out of declarative file declarations', () => {
+    const input = validateAuthoringPlan(plan({
+      structure: [], fields: [], locking: { mode: 'none' }, styles: { strategy: 'native', outcomes: [] },
+      pattern: { ready: false, overrides: [] }, files: [{ path: 'block.json', content: '{}' }],
+    }));
+    expect(() => compileRegisteredBlock(input)).toThrow(/plan file content is not accepted/);
   });
 
   it('validates and hash-binds source identity and the complete analysis ledger', () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -24,6 +24,7 @@ describe('CLI', () => {
     const resolvedProject = await realpath(project);
     const agentsDestination = path.join(resolvedProject, '.agents', 'skills', 'block-runner');
     const claudeDestination = path.join(resolvedProject, '.claude', 'skills', 'block-runner');
+    const sourceGuide = await readFile(new URL('references/GUIDE.md', sourceSkill), 'utf8');
     const result = await runCli(['skill', '--install'], '', {}, project);
 
     expect(result.code).toBe(0);
@@ -36,8 +37,13 @@ describe('CLI', () => {
       expect(skill).toContain(`block-runner@${packageVersion}`);
       expect(guide).toContain(`block-runner@${packageVersion}`);
       expect(skill).not.toContain('block-runner@latest');
-      expect(guide).toContain('block-runner@latest skill --install');
-      expect(guide).not.toMatch(/block-runner@latest (?:assemble|convert|validate|fix)/);
+      expect(sourceGuide).toContain('block-runner@testing author preview');
+      expect(sourceGuide).not.toMatch(/block-runner@latest (?:author|plugin|proof)/);
+      expect(guide).toContain(`block-runner@${packageVersion} author preview`);
+      expect(guide).toContain(`block-runner@${packageVersion} plugin preview`);
+      expect(guide).toContain(`block-runner@${packageVersion} proof`);
+      expect(guide).toContain('block-runner@testing skill --install');
+      expect(guide).not.toMatch(/block-runner@(?:latest|testing) (?:assemble|convert|validate|fix|author|plugin|proof)/);
       expect(JSON.parse(await readFile(path.join(destination, '.block-runner-install.json'), 'utf8'))).toMatchObject({
         schemaVersion: 1,
         skill: 'block-runner',

--- a/test/package-channel.smoke.test.ts
+++ b/test/package-channel.smoke.test.ts
@@ -1,0 +1,78 @@
+import { spawn } from 'node:child_process';
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const tsxImport = import.meta.resolve('tsx');
+const cliPath = new URL('../src/cli.ts', import.meta.url).pathname;
+const sourceGuide = new URL('../skills/block-runner/references/GUIDE.md', import.meta.url);
+
+describe('package channel authoring smoke', () => {
+  it('uses testing for the shipped authoring workflow while stable intentionally lacks author', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'block-runner-channel-smoke-'));
+    const bin = path.join(root, 'bin');
+    const fakeNpx = path.join(bin, 'npx');
+    await mkdir(bin);
+    await writeFile(fakeNpx, `#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+const args = process.argv.slice(2);
+const packageIndex = args.findIndex((value) => value === 'block-runner@latest' || value === 'block-runner@testing');
+const channel = args[packageIndex];
+const command = args.slice(packageIndex + 1);
+if (channel === 'block-runner@latest') {
+  process.stderr.write('stable fixture: author is unavailable\\n');
+  process.exit(2);
+}
+if (channel !== 'block-runner@testing') process.exit(3);
+const result = spawnSync(process.execPath, ['--import', ${JSON.stringify(tsxImport)}, ${JSON.stringify(cliPath)}, ...command], { stdio: 'inherit' });
+process.exit(result.status ?? 1);
+`, 'utf8');
+    await chmod(fakeNpx, 0o755);
+    await writeFile(path.join(root, 'plan.json'), JSON.stringify(plan()), 'utf8');
+
+    const guide = await readFile(sourceGuide, 'utf8');
+    expect(guide).toContain('npx -y block-runner@testing author preview authoring-plan.json');
+    expect(guide).not.toContain('block-runner@latest author preview');
+
+    const testing = await run(fakeNpx, [
+      '-y', 'block-runner@testing', 'author', 'preview', 'plan.json', '--output-dir', 'generated', '--json',
+    ], root);
+    expect(testing.code).toBe(0);
+    expect(JSON.parse(testing.stdout)).toMatchObject({ command: 'author preview', noFilesWritten: true });
+
+    const stable = await run(fakeNpx, ['-y', 'block-runner@latest', 'author', 'preview', 'plan.json'], root);
+    expect(stable.code).toBe(2);
+    expect(stable.stderr).toContain('author is unavailable');
+  });
+});
+
+function plan(): Record<string, unknown> {
+  return {
+    version: 1,
+    generatorVersion: '0.9.0-preview.1',
+    target: { name: 'example/notice', title: 'Notice' },
+    structure: [],
+    fields: [],
+    locking: { mode: 'none' },
+    styles: { strategy: 'native', outcomes: [] },
+    pattern: { ready: false, overrides: [] },
+    assets: [],
+    files: [],
+    warnings: [],
+  };
+}
+
+function run(command: string, args: string[], cwd: string): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}

--- a/test/registered-block.workflow.test.ts
+++ b/test/registered-block.workflow.test.ts
@@ -54,6 +54,13 @@ describe('registered-block workflow', () => {
       '--approve-replace', replacement!, '--json',
     ], root);
     expect(pluginWrite.code).toBe(0);
+    expect(JSON.parse(pluginWrite.stdout)).toMatchObject({
+      delivery: {
+        status: 'source-delivered',
+        buildRuntimeProof: 'not-run',
+        nextCommand: expect.stringContaining('npm run build'),
+      },
+    });
     await expect(readFile(path.join(host, 'src', 'blocks', 'feature-grid', 'index.js'), 'utf8')).resolves.toContain('registerBlockType');
 
     const markup = path.join(root, 'feature-grid.blocks.html');

--- a/test/release-activation-contract.test.ts
+++ b/test/release-activation-contract.test.ts
@@ -193,8 +193,8 @@ describe('release installed skill verification', () => {
   const helperEnd = source.indexOf('\nfunction ', helperStart + 1);
   const digest = (bytes: string | Buffer) => `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
   function fixture() {
-    const original = 'npx block-runner@latest assemble; npx block-runner@latest skill';
-    const installed = 'npx block-runner@0.9.0 assemble; npx block-runner@latest skill';
+    const original = 'npx block-runner@testing author preview; npx block-runner@testing skill';
+    const installed = 'npx block-runner@0.9.0 author preview; npx block-runner@testing skill';
     const files: Record<string, string> = {
       '/pkg/package.json': JSON.stringify({ version: '0.9.0' }),
       '/pkg/skills/block-runner/SKILL.md': original,


### PR DESCRIPTION
## Problem
The README still says author write publishes files[].content and may successfully do nothing, while the compiler now rejects that field. Printed/source guide commands use @latest even though authoring can exist only on the testing channel. Installed skill copies already pin runtime commands correctly; that mechanism should be preserved. The end-to-end route also spans analysis, plan, source output, plugin integration, build and proof, so a user needs an unambiguous next step at each boundary. Closes #34.

## Solution
All three original blockers are resolved: displayed commands are safely quoted and version-pinned, and the review summary now distinguishes style ownership categories. The pull request is ready for review.

## Testing & verification
- **Local run** — `npm run typecheck` → pass.
- **Local run** — `npm run test` → pass.
- **Local run** — `npm run build` → pass.
- CI: passed (4/4).
- **Not run** — no live/manual verification; this Foundry run has no browser.

## QA evidence

QA: not verified — no recipe configured

## Risk / rollout
Small, targeted change — see the diff for the affected paths.


---
*Built by 🪺 Rookery · flight #99 · 53m26s · 2 passes · gpt-5.6-terra·xhigh*