### PR TITLE
Generated editor: preserve layout parity using the actual emitted components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
       "devDependencies": {
         "@types/jsdom": "28.0.0",
         "@types/node": "20.19.0",
+        "esbuild": "0.28.1",
         "tsup": "8.5.1",
         "tsx": "4.23.0",
         "typescript": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   "devDependencies": {
     "@types/jsdom": "28.0.0",
     "@types/node": "20.19.0",
+    "esbuild": "0.28.1",
     "tsup": "8.5.1",
     "tsx": "4.23.0",
     "typescript": "5.9.3",

--- a/scripts/build-pattern-overrides-fixture.ts
+++ b/scripts/build-pattern-overrides-fixture.ts
@@ -51,11 +51,12 @@ export type RootLayoutReproduction = 'grid' | 'flex';
 
 export interface PatternOverridesFixtureOptions {
   /**
-   * Both values compile to the generated wrapper's root, not to a nested Core
-   * group. They are intentionally minimal so before/after layout evidence is
-   * attributable to the useInnerBlocksProps root change.
+   * Both values set the layout on the generated wrapper root. With rootOwned, the
+   * fixture also flattens its semantic group so native siblings exercise that layout.
    */
   rootLayout?: RootLayoutReproduction;
+  /** Flatten the fixture into direct native root children for the layout regression matrix. */
+  rootOwned?: boolean;
 }
 
 /**
@@ -94,10 +95,12 @@ export async function buildPatternOverridesFixture(
 ): Promise<BuiltPatternOverridesFixture> {
   const root = path.resolve(outputDir);
   const rootLayout = options.rootLayout ?? 'grid';
+  const rootOwned = options.rootOwned ?? false;
   const inputPath = path.join(root, 'pattern-overrides.plan.json');
   const pluginDirectory = path.join(root, pluginSlug);
   const pluginZip = path.join(pluginDirectory, `${pluginSlug}.zip`);
   const plan = JSON.parse(await readFile(planPath, 'utf8')) as AuthoringPlan;
+  const layoutPlan = rootOwned ? rootOwnedLayoutPlan(plan) : plan;
   const sourceImage = path.join(root, 'source', 'canonical.png');
   const imageBytes = Buffer.from(PROOF_IMAGE_BASE64, 'base64');
   await mkdir(path.dirname(sourceImage), { recursive: true });
@@ -121,12 +124,12 @@ export async function buildPatternOverridesFixture(
     } }];
   // The retained plan stays portable; the compiler receives resolved files for its asset reads.
   const portablePlan = portableFixturePlan({
-    ...plan,
+    ...layoutPlan,
     assets: assetPlan,
     styles: {
-      ...plan.styles,
+      ...layoutPlan.styles,
       outcomes: [
-        ...plan.styles.outcomes,
+        ...layoutPlan.styles.outcomes,
         { property: 'display', outcome: 'scoped-css', value: rootLayout },
         ...(rootLayout === 'grid'
           ? [{ property: 'grid-template-columns', outcome: 'scoped-css' as const, value: 'minmax(0, 1fr)' }]
@@ -140,6 +143,7 @@ export async function buildPatternOverridesFixture(
     assets: portablePlan.assets.map((asset) => ({ ...asset, source: path.resolve(root, asset.source) })),
   };
   const compiled = compileRegisteredBlock(compilerPlan);
+  const directNativeChildren = compiled.template.map(([name]) => name);
   const contract = validatePatternOverrideContract(compiled.template, []);
   const errors = contract.errors;
   if (errors.length > 0) throw new Error(`The generated pattern fixture plan is invalid: ${errors.join('; ')}`);
@@ -187,10 +191,10 @@ export async function buildPatternOverridesFixture(
     ...(children ? [runtimeTemplate(children)] : []),
   ] as AuthoringTemplate[number]);
   const nativeContainerMarkup = await serializeNativeTemplate(runtimeTemplate(compiled.template));
-  assertBackgroundClass(nativeContainerMarkup, 'initial');
+  if (!rootOwned) assertBackgroundClass(nativeContainerMarkup, 'initial');
   const generatedBlockMarkup = wrapGeneratedBlock(compilerPlan.target.name, nativeContainerMarkup);
   const updatedNativeMarkup = await serializeNativeTemplate(runtimeTemplate(updated.template));
-  assertBackgroundClass(updatedNativeMarkup, 'updated');
+  if (!rootOwned) assertBackgroundClass(updatedNativeMarkup, 'updated');
   const updatedBlockMarkup = wrapGeneratedBlock(compilerPlan.target.name, updatedNativeMarkup);
 
   const fixture = proofFixture({
@@ -200,6 +204,7 @@ export async function buildPatternOverridesFixture(
     requiredBindings: contract.bindings.map(({ name, attribute }) => ({ name, attribute })),
     visualGoldenPath,
     rootLayout,
+    directNativeChildren,
     fontFamily,
   });
   await Promise.all([
@@ -294,6 +299,7 @@ function proofFixture({
   requiredBindings,
   visualGoldenPath,
   rootLayout,
+  directNativeChildren,
   fontFamily,
 }: {
   plan: AuthoringPlan;
@@ -302,6 +308,7 @@ function proofFixture({
   requiredBindings: ProofPatternRequiredBinding[];
   visualGoldenPath: string;
   rootLayout: RootLayoutReproduction;
+  directNativeChildren: readonly string[];
   fontFamily: string;
 }): ProofFixture {
   const nameFor = (pathName: string, attribute: string): string => {
@@ -324,6 +331,7 @@ function proofFixture({
     editableFields: [{ path: 'hero.title', metadataName: title, surface: 'richText', value: 'Proof editor field' }],
     browserMatrix: {
       rootLayout,
+      directNativeChildren,
       fontFamily,
       longContent: 'A deliberately long native heading proves that the generated root remains the layout owner while the editor canvas wraps at narrow widths without creating an InnerBlocks intermediary.',
       image: { width: '240px', height: '60px' },
@@ -389,13 +397,19 @@ function proofFixture({
   };
 }
 
+function rootOwnedLayoutPlan(plan: AuthoringPlan): AuthoringPlan {
+  const layout = plan.structure.find((node) => node.id === 'hero.layout');
+  if (!layout?.children?.length) throw new Error('The root-owned fixture requires the checked-in layout container children.');
+  return { ...plan, structure: structuredClone(layout.children) };
+}
+
 function canonicalUpdatePlan(plan: AuthoringPlan): AuthoringPlan {
   const updated = JSON.parse(JSON.stringify(plan)) as AuthoringPlan;
-  const layout = updated.structure[0];
-  if (!layout) throw new Error('The generated fixture has no native layout container.');
-  layout.attributes = { ...layout.attributes, className: 'block-runner-pattern-layout block-runner-layout-v2' };
-  const title = layout.children?.find((child) => child.id === 'hero.title');
-  const note = layout.children?.find((child) => child.id === 'hero.layout-note');
+  const layout = updated.structure.find((node) => node.id === 'hero.layout');
+  if (layout) layout.attributes = { ...layout.attributes, className: 'block-runner-pattern-layout block-runner-layout-v2' };
+  const children = layout?.children ?? updated.structure;
+  const title = children.find((child) => child.id === 'hero.title');
+  const note = children.find((child) => child.id === 'hero.layout-note');
   if (!title || !note) throw new Error('The generated fixture is missing its title or layout marker.');
   title.attributes = { ...title.attributes, content: 'Canonical fallback after reset' };
   note.attributes = { ...note.attributes, content: 'Canonical layout version two.' };

--- a/scripts/build-pattern-overrides-fixture.ts
+++ b/scripts/build-pattern-overrides-fixture.ts
@@ -11,7 +11,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
-import { compileRegisteredBlock } from '../src/authoring/generate.js';
+import { compileRegisteredBlock, registeredBlockFontFamilyPrefix } from '../src/authoring/generate.js';
 import { patternOverrideName } from '../src/authoring/overrides.js';
 import {
   npmEnvironmentForGeneratedPlugin,
@@ -44,7 +44,19 @@ export function fixtureVisualGoldenPath(platform: string = process.platform): st
 const RETAINED_FIXTURE_ASSET_SOURCES = new Map([
   ['canonical-image', 'source/canonical.png'],
   ['static-logo', 'source/logo.svg'],
+  ['proof-font', 'source/proof-font.woff2'],
 ]);
+
+export type RootLayoutReproduction = 'grid' | 'flex';
+
+export interface PatternOverridesFixtureOptions {
+  /**
+   * Both values compile to the generated wrapper's root, not to a nested Core
+   * group. They are intentionally minimal so before/after layout evidence is
+   * attributable to the useInnerBlocksProps root change.
+   */
+  rootLayout?: RootLayoutReproduction;
+}
 
 /**
  * Keep the checked-in proof input independent of the temporary directory used to build it.
@@ -76,8 +88,12 @@ export interface BuiltPatternOverridesFixture {
  * The plugin, native serialization, canonical wp_block values, and runtime
  * visual-baseline location all derive from the checked-in authoring plan.
  */
-export async function buildPatternOverridesFixture(outputDir: string): Promise<BuiltPatternOverridesFixture> {
+export async function buildPatternOverridesFixture(
+  outputDir: string,
+  options: PatternOverridesFixtureOptions = {},
+): Promise<BuiltPatternOverridesFixture> {
   const root = path.resolve(outputDir);
+  const rootLayout = options.rootLayout ?? 'grid';
   const inputPath = path.join(root, 'pattern-overrides.plan.json');
   const pluginDirectory = path.join(root, pluginSlug);
   const pluginZip = path.join(pluginDirectory, `${pluginSlug}.zip`);
@@ -89,12 +105,36 @@ export async function buildPatternOverridesFixture(outputDir: string): Promise<B
   const sourceSvg = path.join(root, 'source', 'logo.svg');
   const svgBytes = Buffer.from(PROOF_SVG_SOURCE);
   await writeFile(sourceSvg, svgBytes);
+  const sourceFont = path.join(root, 'source', 'proof-font.woff2');
+  const fontBytes = await readFile(path.join(projectRoot, 'test', 'fixtures', 'fonts', 'IBMPlexMono-Regular.woff2'));
+  await writeFile(sourceFont, fontBytes);
+  const fontFamily = `${registeredBlockFontFamilyPrefix(plan.target.name)}proof`;
   const assetPlan: AuthoringPlan['assets'] = [{ id: 'canonical-image', source: 'source/canonical.png', status: 'ready', destination: 'assets/canonical.png',
     sha256: createHash('sha256').update(imageBytes).digest('hex'), uses: [{ node: 'hero.image', attribute: 'url' }] },
   { id: 'static-logo', source: 'source/logo.svg', status: 'ready', destination: 'assets/logo.svg',
-    sha256: createHash('sha256').update(svgBytes).digest('hex'), uses: [{ node: 'hero.logo', attribute: 'url' }] }];
+    sha256: createHash('sha256').update(svgBytes).digest('hex'), uses: [{ node: 'hero.logo', attribute: 'url' }] },
+  { id: 'proof-font', source: 'source/proof-font.woff2', kind: 'font', status: 'ready', destination: 'assets/proof-font.woff2',
+    sha256: createHash('sha256').update(fontBytes).digest('hex'), fontLicense: {
+      ownership: 'Block Runner test fixture',
+      license: 'SIL Open Font License 1.1',
+      notice: 'IBM Plex Mono fixture font used only to observe shared font loading.',
+    } }];
   // The retained plan stays portable; the compiler receives resolved files for its asset reads.
-  const portablePlan = portableFixturePlan({ ...plan, assets: assetPlan });
+  const portablePlan = portableFixturePlan({
+    ...plan,
+    assets: assetPlan,
+    styles: {
+      ...plan.styles,
+      outcomes: [
+        ...plan.styles.outcomes,
+        { property: 'display', outcome: 'scoped-css', value: rootLayout },
+        ...(rootLayout === 'grid'
+          ? [{ property: 'grid-template-columns', outcome: 'scoped-css' as const, value: 'minmax(0, 1fr)' }]
+          : [{ property: 'flex-direction', outcome: 'scoped-css' as const, value: 'column' }]),
+      ],
+      fonts: [{ assetId: 'proof-font', family: fontFamily, fontDisplay: 'block' }],
+    },
+  });
   const compilerPlan: AuthoringPlan = {
     ...portablePlan,
     assets: portablePlan.assets.map((asset) => ({ ...asset, source: path.resolve(root, asset.source) })),
@@ -159,6 +199,8 @@ export async function buildPatternOverridesFixture(outputDir: string): Promise<B
     canonicalUpdateContent: updatedBlockMarkup,
     requiredBindings: contract.bindings.map(({ name, attribute }) => ({ name, attribute })),
     visualGoldenPath,
+    rootLayout,
+    fontFamily,
   });
   await Promise.all([
     writeFixed(path.join(root, 'proof-pattern-overrides.fixture.json'), `${JSON.stringify(fixture, null, 2)}\n`),
@@ -251,12 +293,16 @@ function proofFixture({
   canonicalUpdateContent,
   requiredBindings,
   visualGoldenPath,
+  rootLayout,
+  fontFamily,
 }: {
   plan: AuthoringPlan;
   canonicalContent: string;
   canonicalUpdateContent: string;
   requiredBindings: ProofPatternRequiredBinding[];
   visualGoldenPath: string;
+  rootLayout: RootLayoutReproduction;
+  fontFamily: string;
 }): ProofFixture {
   const nameFor = (pathName: string, attribute: string): string => {
     const field = plan.fields.find((candidate) => candidate.node === pathName && candidate.attribute === attribute);
@@ -276,6 +322,14 @@ function proofFixture({
     // This separate insertion proves the generated wrapper itself exposes a
     // native editor surface before its exact markup becomes a synced pattern.
     editableFields: [{ path: 'hero.title', metadataName: title, surface: 'richText', value: 'Proof editor field' }],
+    browserMatrix: {
+      rootLayout,
+      fontFamily,
+      longContent: 'A deliberately long native heading proves that the generated root remains the layout owner while the editor canvas wraps at narrow widths without creating an InnerBlocks intermediary.',
+      image: { width: '240px', height: '60px' },
+      desktopViewport: { width: 1280, height: 900 },
+      narrowViewport: { width: 390, height: 844 },
+    },
     patternOverrides: {
       title: 'Block Runner generated pattern overrides lifecycle',
       canonicalContent,

--- a/scripts/proof-playwright.mjs
+++ b/scripts/proof-playwright.mjs
@@ -163,16 +163,31 @@ try {
     reopenPersistence,
   });
 
+  // This is intentionally an iframe-only assertion. The direct root is the
+  // regression surface: a page-level mock can prove hook calls but cannot
+  // prove WordPress attached its grid/flex layout and native children to the
+  // same editor-canvas element at both responsive widths.
+  if (fixture.browserMatrix) {
+    const matrix = await phase('editor-root-layout-matrix', () => proveEditorRootLayoutMatrix(page, fixture, artifactDir));
+    const prior = gates.editor_reopen;
+    const passed = prior?.status === 'pass' && matrix.ok;
+    set('editor_reopen', passed ? 'pass' : 'fail', passed ? undefined
+      : matrix.reason ?? prior?.reason ?? 'The generated root layout matrix did not complete.', {
+      ...(prior?.details ?? {}),
+      browserMatrix: matrix.details,
+    }, [...(prior?.artifacts ?? []), ...matrix.artifacts]);
+  }
+
   if (!input.profile || input.profile === 'full') {
   patternLifecycle = await phase('pattern-overrides', () => provePatternOverride(page, fixture));
   const published = await phase('publish', () => publishPost(page, editor));
   const publishedState = await editorState(page);
   publication = published ? await readPublication(page, publishedState.content) : undefined;
-  await phase('accessibility-editor', () => proveAxeEditor(page, fixture));
-  await phase('frontend', () => proveFrontend(page, fixture, baseUrl, publication));
+  await phase('accessibility-editor', () => proveAxeEditor(page, fixture, artifactDir));
+  await phase('frontend', () => proveFrontend(page, fixture, baseUrl, publication, artifactDir));
   await phase('pattern-frontend', () => completePatternOverride(page, fixture, publication, patternLifecycle));
   await phase('visual-regression', () => proveVisual(page, fixture, artifactDir));
-  await phase('accessibility-frontend', () => proveAxeFrontend(page, fixture));
+  await phase('accessibility-frontend', () => proveAxeFrontend(page, fixture, artifactDir));
     blocked('accessibility_manual_review', 'Manual review is verified separately against a saved input/ZIP-bound review record, not inferred from browser automation.');
   }
   }
@@ -440,6 +455,256 @@ async function editorState(page) {
     visit(blocks);
     return { treeHash: await digest(canonical), contentHash: await digest(content), tree: blocks, content, invalidBlocks };
   });
+}
+
+/**
+ * Retain a minimal grid/flex reproduction in the actual WordPress 7.1
+ * editor iframe. The snapshots deliberately keep raw outerHTML as well as
+ * concise observations: a reviewer can inspect both the DOM nesting and the
+ * computed layout rather than having to infer them from a screenshot.
+ */
+async function proveEditorRootLayoutMatrix(page, fixture, artifactDir) {
+  const matrix = fixture.browserMatrix;
+  const artifacts = [];
+  const details = {
+    iframe: { requiredName: 'editor-canvas', observed: false },
+    rootLayout: matrix.rootLayout,
+    fontFamily: matrix.fontFamily,
+    viewports: { desktop: matrix.desktopViewport, narrow: matrix.narrowViewport },
+  };
+  let handles;
+  try {
+    const frame = page.frames().find((candidate) => candidate.name() === 'editor-canvas');
+    if (!frame) throw new Error('WordPress 7.1 editor-canvas iframe was not present; direct-page rendering is not accepted as layout evidence.');
+    details.iframe.observed = true;
+    await page.setViewportSize(matrix.desktopViewport);
+    handles = await generatedRootHandles(page, fixture.blockName);
+    if (handles.roots.length !== 1 || !handles.heading || !handles.image) {
+      throw new Error(`Expected one generated root with a native heading and image before the matrix, found ${handles.roots.length}.`);
+    }
+
+    const keyboard = await exerciseEditorKeyboard(editorCanvas, handles.heading.clientId);
+    const keyboardPath = path.join(artifactDir, `editor-root-${matrix.rootLayout}-keyboard.png`);
+    const keyboardReportPath = path.join(artifactDir, `editor-root-${matrix.rootLayout}-keyboard.json`);
+    await editorCanvas.locator(`[data-block=${JSON.stringify(handles.root.clientId)}]`).screenshot({ path: keyboardPath, animations: 'disabled' });
+    await writeFile(keyboardReportPath, JSON.stringify(keyboard, null, 2), 'utf8');
+    artifacts.push(
+      { path: `artifacts/${path.basename(keyboardPath)}`, mediaType: 'image/png' },
+      { path: `artifacts/${path.basename(keyboardReportPath)}`, mediaType: 'application/json' },
+    );
+
+    const before = await editorRootSnapshot(page, fixture, handles.root.clientId, matrix);
+    const beforeImage = path.join(artifactDir, `editor-root-${matrix.rootLayout}-before-desktop.png`);
+    await editorCanvas.locator(`[data-block=${JSON.stringify(handles.root.clientId)}]`).screenshot({ path: beforeImage, animations: 'disabled' });
+    artifacts.push({ path: `artifacts/${path.basename(beforeImage)}`, mediaType: 'image/png' });
+
+    await updateNativeBlockAttributes(page, handles.heading.clientId, { content: matrix.longContent });
+    await waitForNativeAttribute(page, handles.heading.clientId, 'content', matrix.longContent);
+    const long = await editorRootSnapshot(page, fixture, handles.root.clientId, matrix);
+    const longImage = path.join(artifactDir, `editor-root-${matrix.rootLayout}-after-long-desktop.png`);
+    await editorCanvas.locator(`[data-block=${JSON.stringify(handles.root.clientId)}]`).screenshot({ path: longImage, animations: 'disabled' });
+    artifacts.push({ path: `artifacts/${path.basename(longImage)}`, mediaType: 'image/png' });
+
+    await page.setViewportSize(matrix.narrowViewport);
+    await updateNativeBlockAttributes(page, handles.heading.clientId, { content: '' });
+    await updateNativeBlockAttributes(page, handles.image.clientId, matrix.image);
+    await waitForNativeAttribute(page, handles.heading.clientId, 'content', '');
+    await waitForNativeAttributes(page, handles.image.clientId, matrix.image);
+    const empty = await editorRootSnapshot(page, fixture, handles.root.clientId, matrix);
+    const emptyImage = path.join(artifactDir, `editor-root-${matrix.rootLayout}-after-empty-narrow.png`);
+    await editorCanvas.locator(`[data-block=${JSON.stringify(handles.root.clientId)}]`).screenshot({ path: emptyImage, animations: 'disabled' });
+    artifacts.push({ path: `artifacts/${path.basename(emptyImage)}`, mediaType: 'image/png' });
+
+    // Insert the second generated root through the visible inserter. Its
+    // local native heading is then changed via the same store used by the
+    // editor, while both iframe roots remain visible for the isolation DOM
+    // capture. This avoids treating two selector matches as one instance.
+    await insertThroughVisibleInserter(page, fixture);
+    const pair = await generatedRootHandles(page, fixture.blockName);
+    if (pair.roots.length !== 2 || !pair.roots[0]?.heading || !pair.roots[1]?.heading) {
+      throw new Error(`Expected two visible generated roots for the isolation reproduction, found ${pair.roots.length}.`);
+    }
+    const first = pair.roots.find((root) => root.clientId === handles.root.clientId) ?? pair.roots[0];
+    const second = pair.roots.find((root) => root.clientId !== first.clientId);
+    if (!first?.heading || !second?.heading) throw new Error('Could not identify each generated root\'s native heading.');
+    const isolatedContent = 'First generated root only';
+    await updateNativeBlockAttributes(page, first.heading.clientId, { content: isolatedContent });
+    await waitForNativeAttribute(page, first.heading.clientId, 'content', isolatedContent);
+    const isolation = await editorInstanceIsolationSnapshot(page, fixture, [first.clientId, second.clientId], matrix);
+    const isolationImage = path.join(artifactDir, `editor-root-${matrix.rootLayout}-two-instances-narrow.png`);
+    await editorCanvas.locator(`[data-block=${JSON.stringify(first.clientId)}]`).screenshot({ path: isolationImage, animations: 'disabled' });
+    artifacts.push({ path: `artifacts/${path.basename(isolationImage)}`, mediaType: 'image/png' });
+
+    const matrixEvidence = { before, long, empty, isolation, keyboard };
+    const matrixPath = path.join(artifactDir, `editor-root-${matrix.rootLayout}-matrix.json`);
+    await writeFile(matrixPath, JSON.stringify(matrixEvidence, null, 2), 'utf8');
+    artifacts.push({ path: `artifacts/${path.basename(matrixPath)}`, mediaType: 'application/json' });
+
+    const beforeAfterRoots = [before, long, empty].every((snapshot) => snapshot.ok);
+    const imageChanged = empty.image?.declaredWidth === matrix.image.width && empty.image?.declaredHeight === matrix.image.height;
+    const isolated = isolation.ok && isolation.instances[0]?.text.includes(isolatedContent)
+      && !isolation.instances[1]?.text.includes(isolatedContent);
+    const ok = beforeAfterRoots && long.text.includes(matrix.longContent) && empty.headingContent === ''
+      && imageChanged && isolated && keyboard.ok;
+    details.beforeAfter = {
+      ok: beforeAfterRoots,
+      beforeDomHash: sha256(before.outerHTML),
+      longDomHash: sha256(long.outerHTML),
+      emptyDomHash: sha256(empty.outerHTML),
+      longContentObserved: long.text.includes(matrix.longContent),
+      emptyContentObserved: empty.headingContent === '',
+      alteredImageObserved: imageChanged,
+      directNativeChildren: before.directNativeChildren,
+    };
+    details.isolation = { ok: isolated, rootCount: isolation.instances.length, domHash: sha256(JSON.stringify(isolation)) };
+    details.keyboard = keyboard.summary;
+    return { ok, reason: ok ? undefined : 'Iframe root layout, content variants, image proportions, instance isolation, or keyboard evidence did not match the fixture.', details, artifacts };
+  } catch (error) {
+    details.error = error instanceof Error ? error.message : String(error);
+    return { ok: false, reason: details.error, details, artifacts };
+  } finally {
+    // Restore the exact root used by the normal edit/save/reopen proof and
+    // remove the temporary second instance. The matrix is evidence, not a
+    // hidden change to the post later used for pattern/frontend assertions.
+    if (handles?.heading && handles?.image) {
+      await updateNativeBlockAttributes(page, handles.heading.clientId, handles.heading.attributes).catch(() => undefined);
+      await updateNativeBlockAttributes(page, handles.image.clientId, handles.image.attributes).catch(() => undefined);
+      const roots = await generatedRootHandles(page, fixture.blockName).catch(() => undefined);
+      const temporary = roots?.roots.find((root) => root.clientId !== handles.root.clientId);
+      if (temporary) await removeNativeBlock(page, temporary.clientId).catch(() => undefined);
+    }
+    await page.setViewportSize(matrix.desktopViewport).catch(() => undefined);
+  }
+}
+
+async function generatedRootHandles(page, blockName) {
+  return page.evaluate((name) => {
+    const select = globalThis.wp?.data?.select('core/block-editor');
+    const blocks = select?.getBlocks?.() ?? [];
+    const visit = (block) => [block, ...(block.innerBlocks ?? []).flatMap(visit)];
+    const roots = blocks.filter((block) => block.name === name).map((root) => {
+      const descendants = visit(root);
+      const heading = descendants.find((block) => block.name === 'core/heading');
+      const image = descendants.find((block) => block.name === 'core/image');
+      return {
+        clientId: root.clientId,
+        heading: heading ? { clientId: heading.clientId, attributes: JSON.parse(JSON.stringify(heading.attributes ?? {})) } : undefined,
+        image: image ? { clientId: image.clientId, attributes: JSON.parse(JSON.stringify(image.attributes ?? {})) } : undefined,
+      };
+    });
+    const root = roots[0];
+    return { roots, root, heading: root?.heading, image: root?.image };
+  }, blockName);
+}
+
+async function updateNativeBlockAttributes(page, clientId, attributes) {
+  await page.evaluate(({ id, next }) => {
+    const dispatch = globalThis.wp?.data?.dispatch('core/block-editor');
+    if (!dispatch?.updateBlockAttributes) throw new Error('WordPress block-editor dispatch was unavailable.');
+    dispatch.updateBlockAttributes(id, next);
+  }, { id: clientId, next: attributes });
+}
+
+async function removeNativeBlock(page, clientId) {
+  await page.evaluate((id) => {
+    const dispatch = globalThis.wp?.data?.dispatch('core/block-editor');
+    if (!dispatch?.removeBlock) throw new Error('WordPress block-editor removeBlock was unavailable.');
+    dispatch.removeBlock(id, false);
+  }, clientId);
+}
+
+async function waitForNativeAttribute(page, clientId, attribute, expected) {
+  await page.waitForFunction(({ id, key, value }) => {
+    const actual = globalThis.wp?.data?.select('core/block-editor')?.getBlock?.(id)?.attributes?.[key];
+    return actual === value;
+  }, { id: clientId, key: attribute, value: expected });
+}
+
+async function waitForNativeAttributes(page, clientId, expected) {
+  await page.waitForFunction(({ id, values }) => {
+    const actual = globalThis.wp?.data?.select('core/block-editor')?.getBlock?.(id)?.attributes ?? {};
+    return Object.entries(values).every(([key, value]) => actual[key] === value);
+  }, { id: clientId, values: expected });
+}
+
+async function exerciseEditorKeyboard(canvas, headingId) {
+  const heading = canvas.locator(`[data-block=${JSON.stringify(headingId)}] [contenteditable="true"]`).first();
+  await heading.waitFor({ state: 'visible' });
+  const original = (await heading.textContent()) ?? '';
+  await heading.click();
+  await heading.press('End');
+  await heading.pressSequentially(' keyboard matrix');
+  await heading.press(process.platform === 'darwin' ? 'Meta+z' : 'Control+z');
+  await heading.waitFor({ state: 'visible' });
+  const restored = (await heading.textContent()) ?? '';
+  return {
+    ok: restored === original,
+    summary: { original, restored, undoRestored: restored === original, scope: 'editor-canvas' },
+  };
+}
+
+async function editorRootSnapshot(page, fixture, clientId, matrix) {
+  const root = editorCanvas.locator(`[data-block=${JSON.stringify(clientId)}]`);
+  await root.waitFor({ state: 'visible' });
+  const rootClass = `wp-block-${fixture.blockName.replace('/', '-')}`;
+  return root.evaluate(async (element, { expectedLayout, fontFamily, pluginSlug, rootClass: expectedClass }) => {
+    await document.fonts?.ready;
+    await document.fonts?.load(`16px "${fontFamily}"`);
+    const stylesheets = [...document.styleSheets].map((sheet) => {
+      let hasRootRule = false;
+      try { hasRootRule = [...sheet.cssRules].some((rule) => rule.cssText.includes(expectedClass)); } catch { /* opaque styles are recorded by href below */ }
+      return { href: sheet.href || null, hasRootRule };
+    });
+    const style = getComputedStyle(element);
+    const image = element.querySelector('img');
+    const heading = [...element.querySelectorAll('[data-type="core/heading"]')][0];
+    const direct = [...element.children].map((child) => ({
+      tag: child.tagName.toLowerCase(),
+      block: child.getAttribute('data-type'),
+      clientId: child.getAttribute('data-block'),
+      className: child.className,
+    }));
+    const sharedStyles = stylesheets.some((sheet) => sheet.hasRootRule
+      || Boolean(sheet.href && sheet.href.includes(`/wp-content/plugins/${pluginSlug}/`)));
+    const declaredWidth = image?.style.width || image?.getAttribute('width') || '';
+    const declaredHeight = image?.style.height || image?.getAttribute('height') || '';
+    const snapshot = {
+      scope: window.frameElement?.getAttribute('name') ?? null,
+      outerHTML: element.outerHTML,
+      text: element.textContent ?? '',
+      headingContent: globalThis.wp?.data?.select('core/block-editor')?.getBlock?.(heading?.getAttribute('data-block'))?.attributes?.content ?? null,
+      display: style.display,
+      gridTemplateColumns: style.gridTemplateColumns,
+      flexDirection: style.flexDirection,
+      directNativeChildren: direct.filter((child) => Boolean(child.clientId)).map((child) => child.block),
+      hasInnerBlocksWrapper: Boolean(element.querySelector(':scope > .block-editor-inner-blocks')),
+      sharedStyles,
+      stylesheets,
+      fontLoaded: document.fonts?.check(`16px "${fontFamily}"`) ?? false,
+      image: image ? {
+        declaredWidth,
+        declaredHeight,
+        renderedWidth: Math.round(image.getBoundingClientRect().width),
+        renderedHeight: Math.round(image.getBoundingClientRect().height),
+      } : undefined,
+    };
+    snapshot.ok = snapshot.scope === 'editor-canvas'
+      && snapshot.display === expectedLayout
+      && snapshot.directNativeChildren.length > 0
+      && !snapshot.hasInnerBlocksWrapper
+      && snapshot.sharedStyles
+      && snapshot.fontLoaded;
+    return snapshot;
+  }, { expectedLayout: matrix.rootLayout, fontFamily: matrix.fontFamily, pluginSlug: fixture.pluginSlug ?? fixture.blockName.split('/').slice(1).join('-'), rootClass });
+}
+
+async function editorInstanceIsolationSnapshot(page, fixture, clientIds, matrix) {
+  const snapshots = [];
+  for (const clientId of clientIds) snapshots.push(await editorRootSnapshot(page, fixture, clientId, matrix));
+  return {
+    ok: snapshots.every((snapshot) => snapshot.ok),
+    instances: snapshots.map(({ outerHTML, ...snapshot }) => ({ ...snapshot, outerHTML })),
+  };
 }
 
 async function readPublication(page, savedContent) {
@@ -1377,7 +1642,7 @@ async function proveDeactivation(page, fixture, baseUrl, activePublication) {
     removed ? undefined : 'Plugin-owned editor registration or visible inserter control remained after deactivation.', { block: fixture.blockName, stillRegistered, stillVisible });
 }
 
-async function proveFrontend(page, fixture, baseUrl, activePublication) {
+async function proveFrontend(page, fixture, baseUrl, activePublication, artifactDir) {
   if (!fixture.frontend?.url) {
     for (const gate of ['frontend_status', 'frontend_semantics', 'frontend_links', 'frontend_media', 'frontend_assets', 'frontend_runtime_errors']) {
       blocked(gate, 'Frontend proof needs fixture.frontend.url as an explicit proof scope.');
@@ -1427,12 +1692,64 @@ async function proveFrontend(page, fixture, baseUrl, activePublication) {
   const ownedAssets = pluginOwnedAssets(assets, fixture);
   const ownedStyles = ownedAssets.filter((asset) => asset.resourceType === 'stylesheet');
   const healthyAssets = ownedAssets.every((asset) => asset.delivery === 'inline' || (asset.status >= 200 && asset.status < 400));
-  const assetsPass = ownedStyles.length > 0 && healthyAssets;
-  set('frontend_assets', assetsPass ? 'pass' : 'fail', assetsPass ? undefined : 'No successful plugin-owned stylesheet was observed on the published post, or a plugin asset failed.', { postId: activePublication.id, permalink: activePublication.permalink, assets, ownedAssets, ownedStyles });
+  const sharedMatrix = fixture.browserMatrix ? await frontendSharedStyleSnapshot(page, fixture, artifactDir) : undefined;
+  const assetsPass = ownedStyles.length > 0 && healthyAssets && (sharedMatrix?.ok ?? true);
+  set('frontend_assets', assetsPass ? 'pass' : 'fail', assetsPass ? undefined
+    : sharedMatrix && !sharedMatrix.ok
+      ? 'The generated shared stylesheet/font did not load on the published frontend root.'
+      : 'No successful plugin-owned stylesheet was observed on the published post, or a plugin asset failed.', {
+    postId: activePublication.id,
+    permalink: activePublication.permalink,
+    assets,
+    ownedAssets,
+    ownedStyles,
+    ...(sharedMatrix ? { browserMatrix: sharedMatrix.details } : {}),
+  }, sharedMatrix?.artifacts);
   activePublication.frontendAssets = ownedAssets;
   const scopedErrors = { consoleErrors: consoleErrors.slice(consoleStart), pageErrors: pageErrors.slice(pageErrorStart) };
   const runtimePass = scopedErrors.consoleErrors.length === 0 && scopedErrors.pageErrors.length === 0;
   set('frontend_runtime_errors', runtimePass ? 'pass' : 'fail', runtimePass ? undefined : 'Frontend console or page errors were observed.', { postId: activePublication.id, permalink: activePublication.permalink, ...scopedErrors });
+}
+
+async function frontendSharedStyleSnapshot(page, fixture, artifactDir) {
+  const matrix = fixture.browserMatrix;
+  const rootClass = `wp-block-${fixture.blockName.replace('/', '-')}`;
+  const root = page.locator(`.${rootClass}`).first();
+  const artifacts = [];
+  try {
+    await root.waitFor({ state: 'visible' });
+    const details = await root.evaluate(async (element, { expectedLayout, fontFamily, pluginSlug, expectedClass }) => {
+      await document.fonts?.ready;
+      await document.fonts?.load(`16px "${fontFamily}"`);
+      const style = getComputedStyle(element);
+      const stylesheets = [...document.styleSheets].map((sheet) => {
+        let hasRootRule = false;
+        try { hasRootRule = [...sheet.cssRules].some((rule) => rule.cssText.includes(expectedClass)); } catch { /* href below remains evidence */ }
+        return { href: sheet.href || null, hasRootRule };
+      });
+      const sharedStyles = stylesheets.some((sheet) => sheet.hasRootRule
+        || Boolean(sheet.href && sheet.href.includes(`/wp-content/plugins/${pluginSlug}/`)));
+      return {
+        outerHTML: element.outerHTML,
+        display: style.display,
+        fontLoaded: document.fonts?.check(`16px "${fontFamily}"`) ?? false,
+        sharedStyles,
+        stylesheets,
+      };
+    }, { expectedLayout: matrix.rootLayout, fontFamily: matrix.fontFamily, pluginSlug: fixture.pluginSlug ?? fixture.blockName.split('/').slice(1).join('-'), expectedClass: rootClass });
+    const imagePath = path.join(artifactDir, `frontend-root-${matrix.rootLayout}-shared-style.png`);
+    const jsonPath = path.join(artifactDir, `frontend-root-${matrix.rootLayout}-shared-style.json`);
+    await root.screenshot({ path: imagePath, animations: 'disabled' });
+    await writeFile(jsonPath, JSON.stringify(details, null, 2), 'utf8');
+    artifacts.push(
+      { path: `artifacts/${path.basename(imagePath)}`, mediaType: 'image/png' },
+      { path: `artifacts/${path.basename(jsonPath)}`, mediaType: 'application/json' },
+    );
+    const ok = details.display === matrix.rootLayout && details.fontLoaded && details.sharedStyles;
+    return { ok, details: { ...details, outerHTMLHash: sha256(details.outerHTML) }, artifacts };
+  } catch (error) {
+    return { ok: false, details: { error: error instanceof Error ? error.message : String(error) }, artifacts };
+  }
 }
 
 async function proveVisual(page, fixture, artifactDir) {
@@ -1477,7 +1794,7 @@ async function proveVisual(page, fixture, artifactDir) {
   }
 }
 
-async function proveAxeEditor(page, fixture) {
+async function proveAxeEditor(page, fixture, artifactDir) {
   if (!fixture.accessibility) {
     blocked('accessibility_editor', 'Fixture has no accessibility scope.');
     return;
@@ -1485,10 +1802,16 @@ async function proveAxeEditor(page, fixture) {
   const frame = page.frames().find((candidate) => candidate.name() === 'editor-canvas') ?? page.mainFrame();
   await frame.addScriptTag({ content: axe.source });
   const editor = await frame.evaluate(async (selector) => globalThis.axe.run(selector), fixture.accessibility.editorSelector ?? '.editor-styles-wrapper');
-  set('accessibility_editor', editor.violations.length === 0 ? 'pass' : 'fail', editor.violations.length === 0 ? undefined : 'Axe found editor subtree violations.', { axe: editor, selector: fixture.accessibility.editorSelector ?? '#editor' });
+  const artifact = path.join(artifactDir, 'axe-editor.json');
+  await writeFile(artifact, JSON.stringify(editor, null, 2), 'utf8');
+  set('accessibility_editor', editor.violations.length === 0 ? 'pass' : 'fail', editor.violations.length === 0 ? undefined : 'Axe found editor subtree violations.', {
+    axe: editor,
+    selector: fixture.accessibility.editorSelector ?? '#editor',
+    scope: frame.name() || 'main-frame',
+  }, [{ path: 'artifacts/axe-editor.json', mediaType: 'application/json' }]);
 }
 
-async function proveAxeFrontend(page, fixture) {
+async function proveAxeFrontend(page, fixture, artifactDir) {
   if (!fixture.accessibility) {
     blocked('accessibility_frontend', 'Fixture has no accessibility scope.');
     return;
@@ -1499,7 +1822,9 @@ async function proveAxeFrontend(page, fixture) {
   }
   await page.addScriptTag({ content: axe.source });
   const frontend = await page.evaluate(async (selector) => globalThis.axe.run(selector), fixture.accessibility.frontendSelector ?? fixture.frontend.subtreeSelector ?? 'main');
+  const artifact = path.join(artifactDir, 'axe-frontend.json');
+  await writeFile(artifact, JSON.stringify(frontend, null, 2), 'utf8');
   set('accessibility_frontend', frontend.violations.length === 0 ? 'pass' : 'fail', frontend.violations.length === 0 ? undefined : 'Axe found frontend subtree violations.', {
     axe: frontend, selector: fixture.accessibility.frontendSelector ?? fixture.frontend.subtreeSelector ?? 'main',
-  });
+  }, [{ path: 'artifacts/axe-frontend.json', mediaType: 'application/json' }]);
 }

--- a/scripts/proof-playwright.mjs
+++ b/scripts/proof-playwright.mjs
@@ -670,7 +670,7 @@ async function exerciseEditorKeyboard(page, headingId) {
   // selected after reopening a post. Select the exact heading from the active
   // editor canvas before treating its contenteditable element as ready.
   await selectNativeBlock(page, headingId);
-  const heading = editorCanvas.locator(`[data-block=${JSON.stringify(headingId)}] [contenteditable="true"]`).first();
+  const heading = editorCanvas.locator(`[data-block=${JSON.stringify(headingId)}][contenteditable="true"], [data-block=${JSON.stringify(headingId)}] [contenteditable="true"]`).first();
   await heading.waitFor({ state: 'visible' });
   const original = (await heading.textContent()) ?? '';
   await heading.click();

--- a/scripts/proof-playwright.mjs
+++ b/scripts/proof-playwright.mjs
@@ -253,23 +253,61 @@ async function login(page, baseUrl) {
   ]);
 }
 
-async function waitForEditorReady(page) {
+async function waitForEditorReady(page, { requireCurrentBlocks = false } = {}) {
   await page.waitForFunction(
     () => Boolean(globalThis.wp?.data?.select('core/block-editor')?.getBlocks),
     undefined,
     { timeout: 20_000 },
   );
-  // Depending on the registered block set, WordPress hosts the writing flow
-  // in the API-v3 iframe or directly in the page.
+  // The block-editor data store comes up before either canvas arrangement is
+  // guaranteed. Wait for the first observable canvas surface so we do not
+  // decide on top-level rendering just because the API-v3 iframe is a moment
+  // behind the store.
   await page.locator('iframe[name="editor-canvas"], .block-editor-writing-flow, .editor-styles-wrapper').first()
     .waitFor({ state: 'visible', timeout: 20_000 });
+  // WordPress creates the editor-canvas element before its document has
+  // mounted the writing flow. In particular, a reopened post can expose a
+  // fresh block-store tree while that iframe is still rendering the previous
+  // document. Wait inside the frame before retaining the canvas locator, so
+  // native block client IDs and their editable DOM controls belong to the
+  // same editor instance.
+  const iframe = page.locator('iframe[name="editor-canvas"]');
+  let canvas;
+  if (await iframe.count()) {
+    canvas = page.frameLocator('iframe[name="editor-canvas"]');
+    await canvas.locator('.block-editor-writing-flow, .editor-styles-wrapper').first()
+      .waitFor({ state: 'visible', timeout: 20_000 });
+  } else {
+    // Older WordPress editor configurations render the writing flow directly
+    // in the top-level page.
+    canvas = page;
+    await page.locator('.block-editor-writing-flow, .editor-styles-wrapper').first()
+      .waitFor({ state: 'visible', timeout: 20_000 });
+  }
+  // A visible writing-flow wrapper alone is not proof that this is the
+  // document currently represented by the block store: during a post reopen,
+  // the previous iframe can remain visible while the new store is ready.
+  // Capture the current store's client IDs and require one in this canvas
+  // before it is retained for native-control interactions.
+  const clientIds = await page.waitForFunction((requireBlocks) => {
+    const selector = globalThis.wp?.data?.select('core/block-editor');
+    const visit = (blocks) => blocks.flatMap((block) => [block, ...visit(block.innerBlocks ?? [])]);
+    const ids = visit(selector?.getBlocks?.() ?? [])
+      .map((block) => block.clientId)
+      .filter((clientId) => typeof clientId === 'string' && clientId.length > 0);
+    return !requireBlocks || ids.length > 0 ? ids : false;
+  }, requireCurrentBlocks, { timeout: 20_000 }).then((handle) => handle.jsonValue());
+  if (clientIds.length > 0) {
+    const currentBlockSelector = clientIds
+      .map((clientId) => `[data-block=${JSON.stringify(clientId)}]`)
+      .join(', ');
+    await canvas.locator(currentBlockSelector).first().waitFor({ state: 'visible', timeout: 20_000 });
+  }
+  editorCanvas = canvas;
   const welcome = page.getByRole('dialog', { name: /welcome to the editor/i });
   if (await welcome.isVisible().catch(() => false)) {
     await welcome.getByRole('button', { name: /close/i }).click();
   }
-  editorCanvas = await page.locator('iframe[name="editor-canvas"]').count()
-    ? page.frameLocator('iframe[name="editor-canvas"]')
-    : page;
 }
 async function insertThroughVisibleInserter(page, fixture) {
   const search = await openVisibleInserter(page);
@@ -423,7 +461,7 @@ async function reopenPost(page) {
     const id = await page.evaluate(() => globalThis.wp.data.select('core/editor').getCurrentPostId());
     if (!Number.isInteger(Number(id)) || Number(id) <= 0) return false;
     await page.goto(`${baseUrl}/wp-admin/post.php?post=${Number(id)}&action=edit`, { waitUntil: 'domcontentloaded' });
-    await waitForEditorReady(page);
+    await waitForEditorReady(page, { requireCurrentBlocks: true });
     return true;
   } catch {
     return false;

--- a/scripts/proof-playwright.mjs
+++ b/scripts/proof-playwright.mjs
@@ -521,7 +521,7 @@ async function proveEditorRootLayoutMatrix(page, fixture, artifactDir) {
       throw new Error(`Expected one generated root with a native heading and image before the matrix, found ${handles.roots.length}.`);
     }
 
-    const keyboard = await exerciseEditorKeyboard(editorCanvas, handles.heading.clientId);
+    const keyboard = await exerciseEditorKeyboard(page, handles.heading.clientId);
     const keyboardPath = path.join(artifactDir, `editor-root-${matrix.rootLayout}-keyboard.png`);
     const keyboardReportPath = path.join(artifactDir, `editor-root-${matrix.rootLayout}-keyboard.json`);
     await editorCanvas.locator(`[data-block=${JSON.stringify(handles.root.clientId)}]`).screenshot({ path: keyboardPath, animations: 'disabled' });
@@ -665,8 +665,12 @@ async function waitForNativeAttributes(page, clientId, expected) {
   }, { id: clientId, values: expected });
 }
 
-async function exerciseEditorKeyboard(canvas, headingId) {
-  const heading = canvas.locator(`[data-block=${JSON.stringify(headingId)}] [contenteditable="true"]`).first();
+async function exerciseEditorKeyboard(page, headingId) {
+  // WordPress can defer mounting a native RichText surface until its block is
+  // selected after reopening a post. Select the exact heading from the active
+  // editor canvas before treating its contenteditable element as ready.
+  await selectNativeBlock(page, headingId);
+  const heading = editorCanvas.locator(`[data-block=${JSON.stringify(headingId)}] [contenteditable="true"]`).first();
   await heading.waitFor({ state: 'visible' });
   const original = (await heading.textContent()) ?? '';
   await heading.click();

--- a/scripts/proof-playwright.mjs
+++ b/scripts/proof-playwright.mjs
@@ -689,7 +689,7 @@ async function editorRootSnapshot(page, fixture, clientId, matrix) {
   const root = editorCanvas.locator(`[data-block=${JSON.stringify(clientId)}]`);
   await root.waitFor({ state: 'visible' });
   const rootClass = `wp-block-${fixture.blockName.replace('/', '-')}`;
-  return root.evaluate(async (element, { expectedLayout, fontFamily, pluginSlug, rootClass: expectedClass }) => {
+  return root.evaluate(async (element, { expectedLayout, expectedDirectNativeChildren, fontFamily, pluginSlug, rootClass: expectedClass }) => {
     await document.fonts?.ready;
     await document.fonts?.load(`16px "${fontFamily}"`);
     const stylesheets = [...document.styleSheets].map((sheet) => {
@@ -714,7 +714,7 @@ async function editorRootSnapshot(page, fixture, clientId, matrix) {
       scope: window.frameElement?.getAttribute('name') ?? null,
       outerHTML: element.outerHTML,
       text: element.textContent ?? '',
-      headingContent: globalThis.wp?.data?.select('core/block-editor')?.getBlock?.(heading?.getAttribute('data-block'))?.attributes?.content ?? null,
+      headingContent: heading?.textContent?.replace(/\uFEFF/g, '') ?? null,
       display: style.display,
       gridTemplateColumns: style.gridTemplateColumns,
       flexDirection: style.flexDirection,
@@ -732,12 +732,12 @@ async function editorRootSnapshot(page, fixture, clientId, matrix) {
     };
     snapshot.ok = snapshot.scope === 'editor-canvas'
       && snapshot.display === expectedLayout
-      && snapshot.directNativeChildren.length > 0
+      && JSON.stringify(snapshot.directNativeChildren) === JSON.stringify(expectedDirectNativeChildren)
       && !snapshot.hasInnerBlocksWrapper
       && snapshot.sharedStyles
       && snapshot.fontLoaded;
     return snapshot;
-  }, { expectedLayout: matrix.rootLayout, fontFamily: matrix.fontFamily, pluginSlug: fixture.pluginSlug ?? fixture.blockName.split('/').slice(1).join('-'), rootClass });
+  }, { expectedLayout: matrix.rootLayout, expectedDirectNativeChildren: matrix.directNativeChildren, fontFamily: matrix.fontFamily, pluginSlug: fixture.pluginSlug ?? fixture.blockName.split('/').slice(1).join('-'), rootClass });
 }
 
 async function editorInstanceIsolationSnapshot(page, fixture, clientIds, matrix) {

--- a/src/authoring/generate.ts
+++ b/src/authoring/generate.ts
@@ -29,7 +29,7 @@ import {
  * The owned source-template contract. Changing it changes every generated package and must be an
  * intentional, reviewed release decision.
  */
-export const REGISTERED_BLOCK_TEMPLATE_VERSION = '0.9-static-v8' as const;
+export const REGISTERED_BLOCK_TEMPLATE_VERSION = '0.9-static-v9' as const;
 /**
  * The declarative-style renderer is part of the owned template contract.  It never accepts a
  * stylesheet fragment from the plan: its inputs are validated outcomes and structured rules.
@@ -401,7 +401,7 @@ export function emitEditJs(template: TemplateNode[], allowedBlocks: string[], lo
     });
     return `[${JSON.stringify(name)}, {${entries.join(', ')} }${children ? `, ${renderTemplate(children)}` : ''}]`;
   }).join(',\n')}]`;
-  return `import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+  return `import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 ${imports}
 
 const TEMPLATE = ${assets.length ? renderTemplate(template) : JSON.stringify(template, null, 2)};
@@ -409,14 +409,15 @@ const ALLOWED_BLOCKS = ${JSON.stringify(allowedBlocks, null, 2)};
 const TEMPLATE_LOCK = ${JSON.stringify(templateLock)};
 
 export default function Edit() {
+  const blockProps = useBlockProps();
+  const innerBlocksProps = useInnerBlocksProps( blockProps, {
+    allowedBlocks: ALLOWED_BLOCKS,
+    template: TEMPLATE,
+    templateLock: TEMPLATE_LOCK,
+  } );
+
   return (
-    <div { ...useBlockProps() }>
-      <InnerBlocks
-        allowedBlocks={ ALLOWED_BLOCKS }
-        template={ TEMPLATE }
-        templateLock={ TEMPLATE_LOCK }
-      />
-    </div>
+    <div { ...innerBlocksProps } />
   );
 }
 `;
@@ -424,13 +425,14 @@ export default function Edit() {
 
 /** Typed JSX emitter for static saved markup: native inner blocks own all planned content. */
 export function emitSaveJs(): string {
-  return `import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+  return `import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
 export default function save() {
+  const blockProps = useBlockProps.save();
+  const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+
   return (
-    <div { ...useBlockProps.save() }>
-      <InnerBlocks.Content />
-    </div>
+    <div { ...innerBlocksProps } />
   );
 }
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,6 +238,7 @@ export type {
   ProofEnvironment,
   ProofFilePin,
   ProofFixture,
+  ProofBrowserMatrix,
   ProofGateContext,
   ProofGateResult,
   ProofGateRunner,

--- a/src/proof/runner.ts
+++ b/src/proof/runner.ts
@@ -93,6 +93,8 @@ export interface ProofEditableField {
 export interface ProofBrowserMatrix {
   /** The computed display mode which must belong to the generated root. */
   rootLayout: 'grid' | 'flex';
+  /** Exact native blocks emitted as children of the generated root. */
+  directNativeChildren: readonly string[];
   /** The block-owned family declared by the shared stylesheet. */
   fontFamily: string;
   /** Text written to and then removed from the native heading in the iframe. */

--- a/src/proof/runner.ts
+++ b/src/proof/runner.ts
@@ -84,6 +84,25 @@ export interface ProofEditableField {
   value?: string;
 }
 
+/**
+ * A deliberately small, browser-observable reproduction of a generated
+ * block's root layout.  This is separate from visual regression: it records
+ * the editor-canvas DOM before and after the content cases that used to be
+ * hidden by the extra InnerBlocks wrapper.
+ */
+export interface ProofBrowserMatrix {
+  /** The computed display mode which must belong to the generated root. */
+  rootLayout: 'grid' | 'flex';
+  /** The block-owned family declared by the shared stylesheet. */
+  fontFamily: string;
+  /** Text written to and then removed from the native heading in the iframe. */
+  longContent: string;
+  /** Deliberately non-default native Image proportions observed at narrow width. */
+  image: { width: string; height: string };
+  desktopViewport: { width: number; height: number };
+  narrowViewport: { width: number; height: number };
+}
+
 /** The exact per-instance map WordPress stores at core/block.attributes.content. */
 export type PatternOverrideContent = Record<string, Record<string, unknown>>;
 
@@ -118,6 +137,12 @@ export interface ProofFixture {
   postId?: number;
   blockTitle?: string;
   editableFields?: readonly ProofEditableField[];
+  /**
+   * Opt-in real-browser root-layout evidence. The helper refuses to record a
+   * pass unless WordPress 7.1 rendered the generated root inside editor-canvas
+   * at both declared viewport widths.
+   */
+  browserMatrix?: ProofBrowserMatrix;
   patternOverrides?: {
     /** Exact pattern title inserted through the visible inserter. */
     title: string;

--- a/test/authoring.generate.test.ts
+++ b/test/authoring.generate.test.ts
@@ -115,7 +115,14 @@ describe('registered-block source compiler', () => {
     expect(edit).toContain('Plan once, ship safely');
     expect(edit).toContain('core/paragraph');
     expect(edit).toContain('This is native inner block content.');
-    expect(sourceFile(first.files, 'save.js').content).toContain('InnerBlocks.Content');
+    expect(edit).toContain('useInnerBlocksProps( blockProps');
+    expect(edit).toContain('<div { ...innerBlocksProps } />');
+    expect(edit).not.toContain('<InnerBlocks');
+
+    const save = sourceFile(first.files, 'save.js').content;
+    expect(save).toContain('useInnerBlocksProps.save( blockProps )');
+    expect(save).toContain('<div { ...innerBlocksProps } />');
+    expect(save).not.toContain('InnerBlocks.Content');
 
     const php = sourceFile(first.files, 'block.php').content;
     expect(php).toContain('register_block_type');

--- a/test/authoring.runner.test.ts
+++ b/test/authoring.runner.test.ts
@@ -35,7 +35,7 @@ describe('registered authoring candidate materialization', () => {
     const receipts = path.join(root, 'receipts');
     const manifest = materializeCandidate(fixture, root, candidate, receipts, candidatePlan);
     expect(await readFile(path.join(candidate, 'edit.js'), 'utf8')).toContain('The actual candidate');
-    expect(await readFile(path.join(candidate, 'save.js'), 'utf8')).toContain('InnerBlocks.Content');
+    expect(await readFile(path.join(candidate, 'save.js'), 'utf8')).toContain('useInnerBlocksProps.save( blockProps )');
     expect(existsSync(path.join(candidate, 'src', 'edit.tsx'))).toBe(false);
     expect(existsSync(path.join(candidate, 'style-decisions.json'))).toBe(true);
     expect(existsSync(path.join(candidate, 'style-ledger.json'))).toBe(false);

--- a/test/authoring.runtime.test.ts
+++ b/test/authoring.runtime.test.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { transform } from 'esbuild';
 import { describe, expect, it } from 'vitest';
 import { compileAuthoringPlan } from '../src/index.js';
 import { getWp } from '../src/headless/wp.js';
@@ -15,6 +16,8 @@ type RuntimeBlock = WpBlock & { clientId: string; innerBlocks: RuntimeBlock[] };
 type BlockEditorRuntime = {
   store: unknown;
   BlockInspector: unknown;
+  BlockEditorProvider: unknown;
+  BlockList: unknown;
   useBlockProps: (() => Record<string, unknown>) & { save: () => Record<string, unknown> };
   useInnerBlocksProps: {
     (props: Record<string, unknown>, options: Record<string, unknown>): Record<string, unknown>;
@@ -28,7 +31,7 @@ type DataRuntime = {
 };
 
 type ElementRuntime = {
-  createElement: (type: unknown, props?: Record<string, unknown>) => unknown;
+  createElement: (type: unknown, props?: Record<string, unknown>, ...children: unknown[]) => unknown;
   createRoot: (container: Element) => { render: (element: unknown) => void; unmount: () => void };
   flushSync: (callback: () => void) => void;
 };
@@ -71,29 +74,49 @@ function blocksFromTemplate(wp: WpModules, template: AuthoringTemplate): Runtime
   );
 }
 
-function registerCompiledBlock(
+type GeneratedComponent = () => unknown;
+
+/**
+ * Execute the exact JSX module emitted by the generator. The only transform is
+ * the same JSX-to-JavaScript compilation a block build performs; no edit/save
+ * implementation is re-created in this test.
+ */
+async function loadGeneratedComponent(
+  compiled: CompiledAuthoringBlock,
+  sourcePath: 'edit.js' | 'save.js',
+  moduleOverrides: Record<string, unknown> = {},
+): Promise<GeneratedComponent> {
+  const source = compiled.files[sourcePath];
+  expect(source, `expected generated source file ${sourcePath}`).toBeDefined();
+  const { code } = await transform(source!, {
+    loader: 'jsx',
+    format: 'cjs',
+    jsx: 'automatic',
+    target: 'es2020',
+    sourcefile: sourcePath,
+  });
+  const generatedModule: { exports: Record<string, unknown> } = { exports: {} };
+  const generatedRequire = (specifier: string): unknown => moduleOverrides[specifier] ?? require(specifier);
+  const execute = new Function('require', 'module', 'exports', `${code}\n//# sourceURL=generated-${sourcePath}`) as (
+    moduleRequire: (specifier: string) => unknown,
+    module: { exports: Record<string, unknown> },
+    exports: Record<string, unknown>,
+  ) => void;
+  execute(generatedRequire, generatedModule, generatedModule.exports);
+  expect(generatedModule.exports.default, `expected generated ${sourcePath} default export`).toBeTypeOf('function');
+  return generatedModule.exports.default as GeneratedComponent;
+}
+
+async function registerCompiledBlock(
   wp: WpModules,
   compiled: CompiledAuthoringBlock,
-  editor: BlockEditorRuntime,
-  element: ElementRuntime,
-): string {
+): Promise<string> {
   const metadata = JSON.parse(compiled.files['block.json']!) as Record<string, unknown>;
   const name = metadata.name as string;
-
-  const edit = () => {
-    const blockProps = editor.useBlockProps();
-    const innerBlocksProps = editor.useInnerBlocksProps(blockProps, {
-      allowedBlocks: compiled.allowedBlocks,
-      template: compiled.template,
-      templateLock: compiled.templateLock,
-    });
-    return element.createElement('div', innerBlocksProps);
-  };
-  const save = () => {
-    const blockProps = editor.useBlockProps.save();
-    const innerBlocksProps = editor.useInnerBlocksProps.save(blockProps);
-    return element.createElement('div', innerBlocksProps);
-  };
+  const [edit, save] = await Promise.all([
+    loadGeneratedComponent(compiled, 'edit.js'),
+    loadGeneratedComponent(compiled, 'save.js'),
+  ]);
 
   expect(wp.registerBlockType(metadata, { edit, save })).toBeTruthy();
   return name;
@@ -126,17 +149,65 @@ function expectValidTree(wp: WpModules, block: RuntimeBlock): void {
 }
 
 describe('generated registered blocks in WordPress 7.1', () => {
+  it('loads the emitted components and puts the InnerBlocks layout on their shared root', async () => {
+    const compiled = compileAuthoringPlan(planFor('all'));
+    const calls: Array<{ hook: string; props?: Record<string, unknown>; options?: Record<string, unknown> }> = [];
+    const editBlockProps = { className: 'wp-block-block-runner-runtime-all', 'data-layout-owner': 'edit-root' };
+    const saveBlockProps = { className: 'wp-block-block-runner-runtime-all', 'data-layout-owner': 'save-root' };
+    const editChildren = { kind: 'editor-block-list' };
+    const saveChildren = { kind: 'saved-native-children' };
+    const blockEditor = {
+      useBlockProps: Object.assign(() => {
+        calls.push({ hook: 'useBlockProps' });
+        return editBlockProps;
+      }, {
+        save: () => {
+          calls.push({ hook: 'useBlockProps.save' });
+          return saveBlockProps;
+        },
+      }),
+      useInnerBlocksProps: Object.assign((props: Record<string, unknown>, options: Record<string, unknown>) => {
+        calls.push({ hook: 'useInnerBlocksProps', props, options });
+        return { ...props, className: `${props.className} block-editor-block-list__layout`, children: editChildren };
+      }, {
+        save: (props: Record<string, unknown>) => {
+          calls.push({ hook: 'useInnerBlocksProps.save', props });
+          return { ...props, className: `${props.className} saved-inner-blocks`, children: saveChildren };
+        },
+      }),
+    };
+    const [Edit, save] = await Promise.all([
+      loadGeneratedComponent(compiled, 'edit.js', { '@wordpress/block-editor': blockEditor }),
+      loadGeneratedComponent(compiled, 'save.js', { '@wordpress/block-editor': blockEditor }),
+    ]);
+
+    const edit = Edit() as { type: unknown; props: Record<string, unknown> };
+    const saved = save() as { type: unknown; props: Record<string, unknown> };
+
+    expect(edit).toMatchObject({ type: 'div', props: { className: expect.stringContaining('block-editor-block-list__layout'), children: editChildren } });
+    expect(saved).toMatchObject({ type: 'div', props: { className: expect.stringContaining('saved-inner-blocks'), children: saveChildren } });
+    expect(calls).toEqual([
+      { hook: 'useBlockProps' },
+      {
+        hook: 'useInnerBlocksProps',
+        props: editBlockProps,
+        options: { allowedBlocks: compiled.allowedBlocks, template: compiled.template, templateLock: compiled.templateLock },
+      },
+      { hook: 'useBlockProps.save' },
+      { hook: 'useInnerBlocksProps.save', props: saveBlockProps },
+    ]);
+  });
+
   it.each([false, 'insert', 'all', 'contentOnly'] as const satisfies readonly InnerBlocksLock[])(
     'registers, persists native edits, and enforces %s structural operations',
     async (templateLock) => {
       const wp = await getWp();
       const editor = require('@wordpress/block-editor') as BlockEditorRuntime;
       const data = require('@wordpress/data') as DataRuntime;
-      const element = require('@wordpress/element') as ElementRuntime;
       const actions = data.dispatch(editor.store);
       const selectors = data.select(editor.store);
       const compiled = compileAuthoringPlan(planFor(templateLock));
-      const name = registerCompiledBlock(wp, compiled, editor, element);
+      const name = await registerCompiledBlock(wp, compiled);
       const expected = expectedStructuralOperations(templateLock);
 
       try {
@@ -169,6 +240,65 @@ describe('generated registered blocks in WordPress 7.1', () => {
     },
   );
 
+  it('renders the generated editor root as the direct InnerBlocks layout owner', async () => {
+    const wp = await getWp();
+    const editor = require('@wordpress/block-editor') as BlockEditorRuntime;
+    const data = require('@wordpress/data') as DataRuntime;
+    const element = require('@wordpress/element') as ElementRuntime;
+    const actions = data.dispatch(editor.store);
+    const selectors = data.select(editor.store);
+    const plan = planFor(false);
+    plan.root.children = plan.root.children?.slice(0, 3);
+    const compiled = compileAuthoringPlan(plan);
+    const name = await registerCompiledBlock(wp, compiled);
+    const target = document.createElement('div');
+    const editorRoot = element.createRoot(target);
+
+    try {
+      const mounted = mountCompiledBlock(wp, compiled, actions, selectors);
+      const block = selectors.getBlock(mounted.rootId) as RuntimeBlock;
+      document.body.append(target);
+      element.flushSync(() => editorRoot.render(element.createElement(
+        editor.BlockEditorProvider,
+        { value: [block], settings: {}, onInput: () => {}, onChange: () => {} },
+        element.createElement(editor.BlockList),
+      )));
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      const outer = target.querySelector(`[data-block="${mounted.rootId}"]`);
+      expect(outer).not.toBeNull();
+      expect(outer?.classList.contains('block-editor-block-list__layout')).toBe(true);
+      expect(outer?.querySelector(':scope > .block-editor-inner-blocks')).toBeNull();
+      expect([...outer!.querySelectorAll(':scope > [data-block]')].map((child) => child.getAttribute('data-type')))
+        .toEqual(['core/heading', 'core/paragraph', 'core/image']);
+    } finally {
+      editorRoot.unmount();
+      target.remove();
+      wp.unregisterBlockType(name);
+    }
+  });
+
+  it('accepts pre-v9 saved markup with native children directly below the outer wrapper', async () => {
+    const wp = await getWp();
+    const compiled = compileAuthoringPlan(planFor(false));
+    const name = await registerCompiledBlock(wp, compiled);
+    const nativeChildren = wp.serialize(blocksFromTemplate(wp, compiled.template));
+    // This is the canonical output from the previous `InnerBlocks.Content`
+    // save contract: direct native child comments immediately inside the
+    // generated wrapper, with no editor-only layout wrapper persisted.
+    const legacyMarkup = `<!-- wp:${name} -->\n<div class="wp-block-${name.replace('/', '-')}">${nativeChildren}</div>\n<!-- /wp:${name} -->`;
+
+    try {
+      const reopened = wp.parse(legacyMarkup).map(runtimeBlock);
+
+      expect(reopened).toHaveLength(1);
+      expectValidTree(wp, reopened[0]!);
+      expect(wp.serialize(reopened)).toBe(legacyMarkup);
+    } finally {
+      wp.unregisterBlockType(name);
+    }
+  });
+
   it('observes the WordPress 7.1 Edit pattern Inspector control in the contentOnly fixture', async () => {
     const wp = await getWp();
     const editor = require('@wordpress/block-editor') as BlockEditorRuntime;
@@ -178,7 +308,7 @@ describe('generated registered blocks in WordPress 7.1', () => {
     const selectors = data.select(editor.store);
     const fixture = JSON.parse(await readFile(path.join(FIXTURES, 'content-only.plan.json'), 'utf8')) as AuthoringPlan;
     const compiled = compileAuthoringPlan(fixture);
-    const name = registerCompiledBlock(wp, compiled, editor, element);
+    const name = await registerCompiledBlock(wp, compiled);
     const target = document.createElement('div');
     const inspector = element.createRoot(target);
 

--- a/test/authoring.test.ts
+++ b/test/authoring.test.ts
@@ -103,9 +103,10 @@ describe('registered block authoring compiler', () => {
     const canonical = compileRegisteredBlock(compiled.canonicalPlan!);
     for (const file of canonical.files) expect(compiled.files[file.path]).toBe(file.content);
     expect(compiled.template).toEqual(canonical.template);
-    expect(compiled.files['edit.js']).toContain('allowedBlocks={ ALLOWED_BLOCKS }');
-    expect(compiled.files['edit.js']).toContain('templateLock={ TEMPLATE_LOCK }');
-    expect(compiled.files['save.js']).toContain('<InnerBlocks.Content />');
+    expect(compiled.files['edit.js']).toContain('allowedBlocks: ALLOWED_BLOCKS');
+    expect(compiled.files['edit.js']).toContain('useInnerBlocksProps( blockProps');
+    expect(compiled.files['edit.js']).toContain('templateLock: TEMPLATE_LOCK');
+    expect(compiled.files['save.js']).toContain('useInnerBlocksProps.save( blockProps )');
     expect(JSON.parse(compiled.files['block.json']!).$schema).toBe('https://schemas.wp.org/wp/7.1/block.json');
 
     expect(compiled.editableFields).toEqual(
@@ -153,7 +154,7 @@ describe('registered block authoring compiler', () => {
       const compiled = compileAuthoringPlan(representativePlan(templateLock));
       expect(compiled.templateLock).toBe(templateLock);
       expect(compiled.files['edit.js']).toContain(`const TEMPLATE_LOCK = ${JSON.stringify(templateLock)};`);
-      expect(compiled.files['edit.js']).toContain('templateLock={ TEMPLATE_LOCK }');
+      expect(compiled.files['edit.js']).toContain('templateLock: TEMPLATE_LOCK');
     });
   }
 

--- a/test/proof-mutations.integration.test.ts
+++ b/test/proof-mutations.integration.test.ts
@@ -89,7 +89,7 @@ const enabled = process.env.BLOCK_RUNNER_PROOF_MUTATIONS === '1';
     {
       name: 'save',
       file: 'src/blocks/pattern-overrides-fixture/save.js',
-      mutate: (source) => source.replace('<InnerBlocks.Content />', '<p>Deliberately lost native content</p>'),
+      mutate: (source) => source.replace('<div { ...innerBlocksProps } />', '<div { ...blockProps }><p>Deliberately lost native content</p></div>'),
       target: 'editor_save',
       downstream: ['editor_reopen', 'pattern_overrides', 'frontend_links', 'frontend_media', 'visual_regression'],
     },

--- a/test/proof-real-wordpress.test.ts
+++ b/test/proof-real-wordpress.test.ts
@@ -136,7 +136,7 @@ describe('real WordPress generated-pattern full-profile receipt', () => {
         longContentObserved: true,
         emptyContentObserved: true,
         alteredImageObserved: true,
-        directNativeChildren: expect.arrayContaining(['core/heading', 'core/image']),
+        directNativeChildren: built.fixture.browserMatrix?.directNativeChildren,
       },
       isolation: { ok: true, rootCount: 2 },
       keyboard: { undoRestored: true, scope: 'editor-canvas' },
@@ -181,10 +181,31 @@ describe('real WordPress generated-pattern full-profile receipt', () => {
     expect(matrix).toMatchObject({
       iframe: { observed: true },
       rootLayout: 'flex',
-      beforeAfter: { ok: true, directNativeChildren: expect.arrayContaining(['core/heading', 'core/image']) },
+      beforeAfter: { ok: true, directNativeChildren: built.fixture.browserMatrix?.directNativeChildren },
       isolation: { ok: true, rootCount: 2 },
     });
   }, 480_000);
+
+  it('proves root-owned grid and flex native sibling layouts in the WordPress iframe', async () => {
+    for (const rootLayout of ['grid', 'flex'] as const) {
+      const outputDir = await proofOutputDirectory('root-owned-' + rootLayout);
+      const built = await buildPatternOverridesFixture(outputDir, { rootLayout, rootOwned: true });
+      const result = await runProof({
+        profile: 'editor', pluginZip: built.pluginZip, inputPath: built.inputPath,
+        markup: built.nativeContainerMarkup, fixture: built.fixture, outputDir,
+      });
+      const matrix = (result.receipt.gates.find((gate) => gate.gate === 'editor_reopen')?.details as {
+        browserMatrix?: { iframe?: { observed?: boolean }; rootLayout?: string; beforeAfter?: { ok?: boolean; directNativeChildren?: string[] } };
+      } | undefined)?.browserMatrix;
+      expect(result.profile.ok).toBe(true);
+      expect(built.fixture.browserMatrix?.directNativeChildren).toEqual(expect.arrayContaining(['core/heading', 'core/image']));
+      expect(matrix).toMatchObject({
+        iframe: { observed: true },
+        rootLayout,
+        beforeAfter: { ok: true, directNativeChildren: built.fixture.browserMatrix?.directNativeChildren },
+      });
+    }
+  }, 960_000);
 });
 
 function controlEvidenceFromEnvironment(): ReleaseAcceptanceOptions {

--- a/test/proof-real-wordpress.test.ts
+++ b/test/proof-real-wordpress.test.ts
@@ -29,7 +29,7 @@ const execFileAsync = promisify(execFile);
  * are explicit prerequisites, not optional evidence inputs.
  */
 describe('real WordPress generated-pattern full-profile receipt', () => {
-  it('writes a complete raw WordPress 7.1 receipt and a separate acceptance assessment', async () => {
+  it('writes a complete raw WordPress 7.1 receipt with the retained root-grid iframe matrix and a separate acceptance assessment', async () => {
     await requireDocker();
     const outputDir = await proofOutputDirectory();
     const built = await buildPatternOverridesFixture(outputDir);
@@ -111,8 +111,79 @@ describe('real WordPress generated-pattern full-profile receipt', () => {
     expect(lifecycle?.edited?.every((instance) => instance.ok === true && instance.scope?.outsideUnchanged === true)).toBe(true);
     expect(lifecycle?.preSaveCoreBlockContent?.[0]?.content)
       .not.toEqual(lifecycle?.preSaveCoreBlockContent?.[1]?.content);
+
+    const editorReopen = result.receipt.gates.find((gate) => gate.gate === 'editor_reopen');
+    const gridMatrix = (editorReopen?.details as {
+      browserMatrix?: {
+        iframe?: { observed?: boolean };
+        rootLayout?: string;
+        beforeAfter?: {
+          ok?: boolean;
+          longContentObserved?: boolean;
+          emptyContentObserved?: boolean;
+          alteredImageObserved?: boolean;
+          directNativeChildren?: string[];
+        };
+        isolation?: { ok?: boolean; rootCount?: number };
+        keyboard?: { undoRestored?: boolean; scope?: string };
+      };
+    } | undefined)?.browserMatrix;
+    expect(gridMatrix).toMatchObject({
+      iframe: { observed: true },
+      rootLayout: 'grid',
+      beforeAfter: {
+        ok: true,
+        longContentObserved: true,
+        emptyContentObserved: true,
+        alteredImageObserved: true,
+        directNativeChildren: expect.arrayContaining(['core/heading', 'core/image']),
+      },
+      isolation: { ok: true, rootCount: 2 },
+      keyboard: { undoRestored: true, scope: 'editor-canvas' },
+    });
+    expect(retainedMediaTypes(editorReopen).filter((mediaType) => mediaType === 'image/png').length).toBeGreaterThanOrEqual(4);
+    expect(retainedMediaTypes(editorReopen)).toContain('application/json');
+    // Keyboard and automated accessibility evidence are retained by separate
+    // gates/artifacts rather than being inferred from one generic screenshot.
+    expect(retainedMediaTypes(result.receipt.gates.find((gate) => gate.gate === 'accessibility_editor'))).toContain('application/json');
+    expect(retainedMediaTypes(result.receipt.gates.find((gate) => gate.gate === 'accessibility_frontend'))).toContain('application/json');
+    const frontendMatrix = (result.receipt.gates.find((gate) => gate.gate === 'frontend_assets')?.details as {
+      browserMatrix?: { display?: string; fontLoaded?: boolean; sharedStyles?: boolean };
+    } | undefined)?.browserMatrix;
+    expect(frontendMatrix).toMatchObject({ display: 'grid', fontLoaded: true, sharedStyles: true });
+    expect(retainedMediaTypes(result.receipt.gates.find((gate) => gate.gate === 'frontend_assets'))).toContain('image/png');
     await expect(readFile(path.join(outputDir, result.receiptReference.path), 'utf8'))
       .resolves.toBe(canonicalJson(result.receipt));
+  }, 480_000);
+
+  it('retains the minimal root-flex iframe reproduction at desktop and narrow widths', async () => {
+    await requireDocker();
+    const outputDir = await proofOutputDirectory('root-flex');
+    const built = await buildPatternOverridesFixture(outputDir, { rootLayout: 'flex' });
+    const result = await runProof({
+      profile: 'editor',
+      pluginZip: built.pluginZip,
+      inputPath: built.inputPath,
+      markup: built.nativeContainerMarkup,
+      fixture: built.fixture,
+      outputDir,
+    });
+    const matrix = (result.receipt.gates.find((gate) => gate.gate === 'editor_reopen')?.details as {
+      browserMatrix?: {
+        iframe?: { observed?: boolean };
+        rootLayout?: string;
+        beforeAfter?: { ok?: boolean; directNativeChildren?: string[] };
+        isolation?: { ok?: boolean; rootCount?: number };
+      };
+    } | undefined)?.browserMatrix;
+
+    expect(result.profile.ok).toBe(true);
+    expect(matrix).toMatchObject({
+      iframe: { observed: true },
+      rootLayout: 'flex',
+      beforeAfter: { ok: true, directNativeChildren: expect.arrayContaining(['core/heading', 'core/image']) },
+      isolation: { ok: true, rootCount: 2 },
+    });
   }, 480_000);
 });
 
@@ -121,6 +192,12 @@ function controlEvidenceFromEnvironment(): ReleaseAcceptanceOptions {
     nativeHeadingControlEvidence: headingControlEvidenceFromEnvironment(),
     nativeParagraphControlEvidence: paragraphControlEvidenceFromEnvironment(),
   };
+}
+
+function retainedMediaTypes(gate: { evidence?: unknown } | undefined): string[] {
+  if (!Array.isArray(gate?.evidence)) return [];
+  return gate.evidence.flatMap((value) => value && typeof value === 'object' && 'mediaType' in value
+    && typeof value.mediaType === 'string' ? [value.mediaType] : []);
 }
 
 function headingControlEvidenceFromEnvironment(): NativeHeadingControlEvidence | undefined {
@@ -156,10 +233,10 @@ function paragraphControlEvidenceFromEnvironment(): NativeParagraphControlEviden
  * evidence object can be uploaded after this test. Local runs remain isolated
  * in a temporary directory.
  */
-async function proofOutputDirectory(): Promise<string> {
+async function proofOutputDirectory(suffix?: string): Promise<string> {
   const configured = process.env.BLOCK_RUNNER_PROOF_OUTPUT_DIR;
   if (!configured) return mkdtemp(path.join(tmpdir(), 'block-runner-real-proof-'));
-  const outputDir = path.resolve(configured);
+  const outputDir = path.resolve(configured, suffix ?? '.');
   await mkdir(outputDir, { recursive: true });
   return outputDir;
 }


### PR DESCRIPTION
## Problem
Generated editor markup inserted an InnerBlocks wrapper while saved markup placed children directly under the block root. That difference breaks root grid/flex and direct-child layouts. The old runtime test substituted handwritten components and could miss emitter regressions. Closes #26.

## Solution
Generate edit/save components with matching `useBlockProps` and `useInnerBlocksProps` contracts, and exercise the emitted modules. Extend the WordPress iframe proof to retain layout, content, font, isolation and keyboard evidence at desktop and narrow widths.

The repair adds dedicated root-owned grid/flex fixtures with native sibling blocks. It checks the exact direct-child sequence and absence of an intervening InnerBlocks wrapper, reads content in the iframe itself, and treats Gutenberg’s empty RichText placeholder as empty.

## Shape of the change
+777 −74 · 13 files

```text
src/
├── authoring/generate.ts              # matching edit/save hooks; template v9
├── proof/runner.ts                    # explicit browser matrix contract
└── index.ts
scripts/
├── build-pattern-overrides-fixture.ts # dedicated root-owned grid/flex cases
└── proof-playwright.mjs               # iframe DOM and interaction evidence
test/
├── authoring.*.test.ts                # emitted component and generation coverage
├── proof-mutations.integration.test.ts
└── proof-real-wordpress.test.ts       # real WordPress 7.1 acceptance
package.json / package-lock.json       # pinned test bundler dependency
```

## Testing & verification
Current head: `df81a15ca7c6cde2cbc47b7a619e3a85cedf692d`.

- Mini typecheck passed; 22 focused tests passed.
- Real WordPress suite passed 3/3 in 444.29 seconds, including dedicated root-owned grid and flex native-sibling cases.
- Current-head GitHub Node 20, 22 and 24 checks and WordPress proof all passed.
- Review reconciliation: original implementation and the preceding CI repair received independent Warden approval; the latest four-file repair was independently reviewed by the coordinating agent with no remaining must-fix findings.
- Compatibility: the emitted-component test parses pre-v9 direct-native-child saved markup and asserts byte-identical reserialization; it passed in the 22-test targeted run.
- The earlier WordPress CI failure is retained as history; the new proof fixes the actual fixture/iframe failures rather than removing required layout assertions.

## Risk / rollout
The generated source template changes from v8 to v9. Saved-markup compatibility and real iframe evidence must remain part of review. This PR does not merge, publish a package, run benchmarks, or deploy a consumer site.
