### PR TITLE
Author analysis: prevent media uploads before confirmation

### DIFF
--- a/src/author/index.ts
+++ b/src/author/index.ts
@@ -10,6 +10,7 @@ import {
   AuthorConfig,
   AuthorOptions,
   BlockRunnerReport,
+  ConvertOptions,
   GeneratedBlockPackage,
   ReportItem,
 } from '../types.js';
@@ -297,7 +298,7 @@ export async function author(input: string, options: AuthorOptions = {}): Promis
   // `<style>` node for its class rules, and Tailwind source would be incorrectly treated as an
   // empty stylesheet.
   const sourceStyledInput = withAuthorStyles(input, styleInput);
-  const nativeSource = await collectNativeSourceDeclarations(sourceStyledInput, options, config);
+  const nativeSource = await collectNativeSourceDeclarations(sourceStyledInput, authorAnalysisOptions(options), config);
   const preflightStyleLedger = [...safetyLedger, ...nativeSource.inlineLedger];
   const preflightInlineFailure = nativeSource.inlineLedger.some(
     (entry) => entry.outcome === 'blocked' || entry.outcome === 'warned',
@@ -345,7 +346,7 @@ export async function author(input: string, options: AuthorOptions = {}): Promis
 
   const inlineStyleLedger: AuthoredStyleLedgerEntry[] = [];
   const conversion = await convert(withAuthorStyles(rewrittenMarkup.input, styleInput), {
-    ...options,
+    ...authorAnalysisOptions(options),
     // The author package carries residual authored selectors/properties in style.scss; the
     // legacy open sidecar would duplicate it as a global post stylesheet.
     styling: 'relaxed',
@@ -433,6 +434,16 @@ export async function author(input: string, options: AuthorOptions = {}): Promis
     styleLedger: compiled ? [...styleLedger, ...compiled.editorStyleLedger] : styleLedger,
     package: packageSource,
   };
+}
+
+/**
+ * The two conversion passes in HTML authoring are capability probes, not a delivery step.  They
+ * must retain the source URL and report unresolved media, but may never search, sideload, or
+ * import it through the destination configured by a caller.  `resolver` has precedence over the
+ * merged config, so this also protects callers that supplied the resolver as an option.
+ */
+function authorAnalysisOptions(options: AuthorOptions): ConvertOptions {
+  return { ...options, resolver: 'noop' };
 }
 
 function mergeAuthorConfig(configured: AuthorConfig | undefined, explicit: AuthorConfig | undefined): AuthorConfig {

--- a/test/author.media-isolation.test.ts
+++ b/test/author.media-isolation.test.ts
@@ -1,0 +1,73 @@
+import { chmod, mkdir, mkdtemp, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { author } from '../src/author/index.js';
+
+async function fixture(): Promise<{ root: string; image: string; missing: string }> {
+  const root = await mkdtemp(path.join(tmpdir(), 'block-runner-author-media-'));
+  await writeFile(path.join(root, 'photo.png'), 'not an image, but a readable source asset');
+  return { root, image: 'photo.png', missing: 'missing.png' };
+}
+
+function markup(image: string, missing: string): string {
+  return `<img src="${image}" alt="Prepared"><img src="${missing}" alt="Missing">`;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('HTML authoring media isolation', () => {
+  it('does not call a configured REST resolver during repeated analysis or asset validation failure', async () => {
+    const input = await fixture();
+    const fetch = vi.fn(() => {
+      throw new Error('author analysis must not contact the REST media boundary');
+    });
+    vi.stubGlobal('fetch', fetch);
+
+    const options = {
+      sourcePath: path.join(input.root, 'design.html'),
+      author: { name: 'example/media' },
+      config: { media: { resolver: 'rest' as const, wpUrl: 'https://wordpress.example.test', allowRemote: true } },
+    };
+    const first = await author(markup(input.image, input.missing), options);
+    const second = await author(markup(input.image, input.missing), options);
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(first.ok).toBe(false);
+    expect(second.ok).toBe(false);
+    expect(first.assets).toContainEqual(expect.objectContaining({ reference: input.missing, outcome: 'unresolved' }));
+    expect(first.output).toContain('./assets/');
+    expect(first.output).not.toMatch(/"id"\s*:\s*\d+/);
+  });
+
+  it('does not invoke configured WP-CLI lookup or import during repeated analysis', async () => {
+    const input = await fixture();
+    const bin = path.join(input.root, 'bin');
+    const wp = path.join(bin, 'wp');
+    const audit = path.join(input.root, 'wp-invocations.log');
+    await mkdir(bin);
+    await writeFile(wp, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(audit)}\nexit 1\n`);
+    await chmod(wp, 0o755);
+    const oldPath = process.env.PATH;
+    process.env.PATH = `${bin}${path.delimiter}${oldPath ?? ''}`;
+
+    try {
+      const options = {
+        sourcePath: path.join(input.root, 'design.html'),
+        author: { name: 'example/media' },
+        config: { media: { resolver: 'wpcli' as const, wpUrl: 'https://wordpress.example.test', allowRemote: true } },
+      };
+      const first = await author(markup(input.image, input.missing), options);
+      const second = await author(markup(input.image, input.missing), options);
+
+      expect(first.ok).toBe(false);
+      expect(second.ok).toBe(false);
+      await expect(stat(audit)).rejects.toMatchObject({ code: 'ENOENT' });
+      expect(first.assets).toContainEqual(expect.objectContaining({ reference: input.missing, outcome: 'unresolved' }));
+    } finally {
+      process.env.PATH = oldPath;
+    }
+  });
+});


### PR DESCRIPTION
## Problem
HTML authoring analysis calls the page-content converter twice, including shared media finalisation. Both calls inherit the caller's media configuration. A review probe with a mocked REST resolver recorded two media-upload POST attempts before any authoring confirmation. No live uploads were performed in the probe. Closes #24.

## Solution
Implementation details and verification evidence are recorded separately below.

## Shape of the change

+86 −2 · 2 files

```text
Changed files
  "src/author/index.ts"
  "test/author.media-isolation.test.ts"
```

## Testing & verification
- **Local run** — `npm run typecheck` → pass; environment: node@0a49bc370fca; revision: `88ee938f319a`.
- **Local run** — `npm run test` → pass; environment: node@0a49bc370fca; revision: `88ee938f319a`.
- **Local run** — `npm run build` → pass; environment: node@0a49bc370fca; revision: `88ee938f319a`.
- **Issue checks** — none recorded by the factory.
- CI: passed (4/4).
- **Not run** — no live/manual verification; this Foundry run has no browser.

**Delivery status:** published; verification blocked.

## Effective verification posture

This public open source repository uses relevant functional checks and pragmatic runtime proof.
Visual or browser evidence was not selected: no changed interaction or explicit browser acceptance; execution: not_configured.

## QA evidence

QA: not verified — no recipe configured
No capture recipe was configured; matching verification receipts: repository:typecheck, repository:test, repository:build.

## Risk / rollout
Small, targeted change — see the diff for the affected paths.


---
*Built by 🪺 Rookery · flight #130 · 21m53s · 1 pass · gpt-5.6-terra·medium*