### PR TITLE
Prepare 0.9 owner acceptance workflows

### DIFF
--- a/acceptance/0.9-testing/README.md
+++ b/acceptance/0.9-testing/README.md
@@ -1,0 +1,58 @@
+# 0.9 owner-acceptance inputs
+
+This directory prepares the two bounded workflows from issue #54. It is not
+an authoring benchmark, a release receipt, or evidence that a real-project
+journey has passed. The two inputs are project-authored fixtures committed in
+`af0808f`; their exact bytes and repository licence are recorded in
+[`inputs.json`](./inputs.json).
+
+The fixture pair deliberately separates the risks that need to be seen in an
+ordinary session: the semantic feature carries a checked local SVG and
+alternative text; the utility-CSS feature carries the 1/2/4-column responsive
+rules and reduced-motion treatment. Neither fixture is presented as an
+unfamiliar external design. A later real-project input must be supplied and
+licensed explicitly before making that claim.
+
+## Prepare one candidate
+
+Work from the revision pinned in `inputs.json`, or update that revision and all
+input hashes together. Pack the CLI and use the packed tarball and its shipped
+skill in a clean consumer project. Copy the input HTML and its listed local
+dependencies into the candidate evidence directory before analysis; retain the
+copy and hash, not merely a path back to this checkout.
+
+For each journey, follow the shipped guide's sequence: `author` analysis,
+save the canonical plan, `author preview`, obtain an explicit confirmation for
+the displayed hash, `author write`, `plugin preview/write`, build the plugin
+ZIP, then run the applicable `proof` profile. Source generation alone is not
+an installable-plugin claim. Record corrections to the plan as corrections,
+not as if they had been in the original input.
+
+The standard proof fixture may be used for the shared pattern and regeneration
+exercises named in `inputs.json`; it does not replace either of these supplied
+design journeys. Keep raw proof failures and the narrow 0.9 native-control
+exception visible under the existing release policy.
+
+## Owner session
+
+Prepare the candidate and access instructions before asking the owner to join.
+The owner should spend about 20–30 minutes on the remaining judgement:
+
+1. Inspect each block in the normal editor: its fixed structure, editable
+   fields, local asset handling, and the responsive layout controls.
+2. Save, reopen, and inspect the frontend at the relevant widths; decide
+   whether the visual result and editing feel are acceptable.
+3. Review the retained accessibility result and any unresolved diagnostics.
+
+Only the owner can authorise confirmation/replacement decisions and make the
+visual, editing-feel, and manual-accessibility judgements. Those decisions must
+remain `required` or `blocked` until a hash-bound record is retained; an agent
+must not mark them passed.
+
+## Later fixes
+
+For a source or style change after preparation, rerun the affected journey's
+generation/build/proof checks and the applicable shared integration exercise.
+Repeat the owner session only when the edited behaviour can affect visual
+fidelity, editing feel, accessibility judgement, or the approved confirmation
+surface; otherwise explain why the retained owner evidence still applies.

--- a/acceptance/0.9-testing/README.md
+++ b/acceptance/0.9-testing/README.md
@@ -15,18 +15,90 @@ licensed explicitly before making that claim.
 
 ## Prepare one candidate
 
-Work from the revision pinned in `inputs.json`, or update that revision and all
-input hashes together. Pack the CLI and use the packed tarball and its shipped
-skill in a clean consumer project. Copy the input HTML and its listed local
-dependencies into the candidate evidence directory before analysis; retain the
-copy and hash, not merely a path back to this checkout.
+Start from a fresh checkout of the candidate and record its full Git revision;
+the preparation revision in `inputs.json` is not a release-candidate claim.
+Before any analysis, use the small staging harness below. It checks the pinned
+source bytes and refuses to overwrite an evidence directory:
 
-For each journey, follow the shipped guide's sequence: `author` analysis,
-save the canonical plan, `author preview`, obtain an explicit confirmation for
-the displayed hash, `author write`, `plugin preview/write`, build the plugin
-ZIP, then run the applicable `proof` profile. Source generation alone is not
-an installable-plugin claim. Record corrections to the plan as corrections,
-not as if they had been in the original input.
+```sh
+node acceptance/0.9-testing/prepare-inputs.mjs --check
+node acceptance/0.9-testing/prepare-inputs.mjs \
+  --output /absolute/path/to/evidence/inputs \
+  --candidate-revision "$(git rev-parse HEAD)"
+```
+
+The staged layout preserves each input's relative CSS and asset references and
+writes `input-receipt.json`. Pack the CLI and use the packed tarball and its
+shipped skill in a clean consumer project. Retain the tarball and its hash; do
+not analyse from this checkout after staging.
+
+```sh
+mkdir -p /absolute/path/to/evidence/package /absolute/path/to/evidence/consumer
+npm pack --pack-destination /absolute/path/to/evidence/package
+cd /absolute/path/to/evidence/consumer
+npm init -y
+npm install --ignore-scripts --save-exact /absolute/path/to/evidence/package/block-runner-0.9.0.tgz
+npx --no-install block-runner skill --install --dir .agents/skills
+```
+
+For each journey, run analysis with the packed CLI and save the whole JSON
+report before extracting `package.canonicalPlan`. Keep plans in the evidence
+directory and invoke the packed binary by absolute path: `author preview` and
+`author write` intentionally accept only safe, relative plan paths. The
+responsive input has a linked stylesheet, so create a consumer-local
+configuration that supplies the staged `tailwind-responsive.css` as
+`author.styles.css` with `author.styles.mode: 'css'`; it is compiled CSS, not
+permission to run a Tailwind project. The local-asset journey needs no
+stylesheet configuration.
+
+```sh
+# Set these after installing the packed tarball.
+export EVIDENCE=/absolute/path/to/evidence
+export BLOCK_RUNNER="$EVIDENCE/consumer/node_modules/.bin/block-runner"
+
+# Journey 1: local SVG. Run from the journey directory so the plan path is safe and relative.
+mkdir -p "$EVIDENCE/local-asset-feature"
+cd "$EVIDENCE/local-asset-feature"
+"$BLOCK_RUNNER" author \
+  "$EVIDENCE/inputs/local-asset-feature/benchmarks/authoring/sources/semantic/local-assets.html" \
+  --name block-runner/asset-feature --json > analysis.json
+
+# Journey 2: retain compiled CSS explicitly; do not run Tailwind or load its config.
+mkdir -p "$EVIDENCE/responsive-panel-grid"
+node --input-type=module -e '
+  import { readFile, writeFile } from "node:fs/promises";
+  const css = await readFile(process.argv[1], "utf8");
+  await writeFile(process.argv[2], `${JSON.stringify({ author: { styles: { mode: "css", css } } }, null, 2)}\\n`);
+' "$EVIDENCE/inputs/responsive-panel-grid/benchmarks/authoring/sources/utility/tailwind-responsive.css" \
+  "$EVIDENCE/responsive-panel-grid/block-runner.config.mjs"
+cd "$EVIDENCE/responsive-panel-grid"
+"$BLOCK_RUNNER" author \
+  "$EVIDENCE/inputs/responsive-panel-grid/benchmarks/authoring/sources/utility/tailwind-responsive.html" \
+  --name block-runner/responsive-panel-grid --config block-runner.config.mjs --json > analysis.json
+
+# Run this in each journey directory after analysis. It stops if no usable canonical plan was produced.
+node --input-type=module -e '
+  import { readFile, writeFile } from "node:fs/promises";
+  const report = JSON.parse(await readFile(process.argv[1], "utf8"));
+  if (!report.ok || !report.package?.canonicalPlan) throw new Error("No canonical plan in analysis report");
+  await writeFile(process.argv[2], `${JSON.stringify(report.package.canonicalPlan, null, 2)}\\n`);
+' analysis.json authoring-plan.json
+"$BLOCK_RUNNER" author preview authoring-plan.json --output-dir "$PWD/generated" > preview.txt
+```
+
+Show the complete preview. Only after the owner authorises its exact hash, run
+`author write` with that hash and exact destination. Then use `plugin inspect`,
+`plugin preview`, and `plugin write` against a supported existing-plugin target
+(with separately approved replacements), build its normal ZIP, and invoke
+`proof --profile full` with a fixture whose editable fields, visual baseline,
+and manual-review scope were created for that generated package. Source
+generation alone is not an installable-plugin claim. Record corrections to the
+plan as corrections, not as if they had been in the original input.
+
+The full proof cannot be prefilled from this manifest: its fixture must bind
+the generated block name/markup, editable inventory, pattern assertions,
+reviewed golden, and manual-review file to the final ZIP. Until those inputs
+exist, `proof` is correctly blocked rather than runnable evidence.
 
 The standard proof fixture may be used for the shared pattern and regeneration
 exercises named in `inputs.json`; it does not replace either of these supplied

--- a/acceptance/0.9-testing/inputs.json
+++ b/acceptance/0.9-testing/inputs.json
@@ -1,0 +1,85 @@
+{
+  "version": 1,
+  "candidateRevision": "58dc3b973313c75563610a6ea5cf532c98efa83b",
+  "status": "prepared-not-run",
+  "purpose": "Two repository-controlled inputs for the 0.9 owner-acceptance journeys. This manifest is not a benchmark receipt and does not claim real-project coverage.",
+  "sourceProvenance": {
+    "commit": "af0808fbf5e0f0487bbc7954c119fe6de0de0739",
+    "author": "Noel Tock",
+    "repositoryLicense": "GPL-2.0-or-later",
+    "notice": "These are repository fixtures. They are suitable for preparing the two bounded workflows, but do not establish that equivalent real-project inputs are already available."
+  },
+  "journeys": [
+    {
+      "id": "local-asset-feature",
+      "title": "Semantic local-asset feature",
+      "source": {
+        "html": "../../benchmarks/authoring/sources/semantic/local-assets.html",
+        "sha256": "sha256:35b26914c6b3dc05d8c3b3bfa205bf05be27240defc35f61bfbbc7a57b0f595b"
+      },
+      "dependencies": [
+        {
+          "path": "../../benchmarks/authoring/sources/assets/aurora-dashboard.svg",
+          "sha256": "sha256:18ab15d443086fa3fc379734c0f0e86b891535ea222f6499e0b37170067e6cf9",
+          "role": "bundled local SVG"
+        }
+      ],
+      "target": {
+        "name": "block-runner/asset-feature",
+        "title": "Asset feature"
+      },
+      "requiredObservations": [
+        "The SVG is copied as a bundled asset and the built URL is used; no network or data URL substitute is accepted.",
+        "The supplied alternative text is editable, survives save/reopen, and remains meaningful on the frontend.",
+        "Fixed structure and editable copy are visible in the ordinary editor."
+      ]
+    },
+    {
+      "id": "responsive-panel-grid",
+      "title": "Responsive utility-CSS panel grid",
+      "source": {
+        "html": "../../benchmarks/authoring/sources/utility/tailwind-responsive.html",
+        "sha256": "sha256:511be4b715b86583db068aeeabb02a39e6d307bff22835d84bacc14a2ed4eea0"
+      },
+      "dependencies": [
+        {
+          "path": "../../benchmarks/authoring/sources/utility/tailwind-responsive.css",
+          "sha256": "sha256:79e70276b0bd916229d1cc19c344891493f94b07aedef8594d7e4de6ffb0d3af",
+          "role": "compiled responsive utility CSS"
+        }
+      ],
+      "target": {
+        "name": "block-runner/responsive-panel-grid",
+        "title": "Responsive panel grid"
+      },
+      "requiredObservations": [
+        "The generated package has no Tailwind runtime dependency.",
+        "The 1/2/4-column breakpoints and reduced-motion rule are retained in the generated frontend stylesheet.",
+        "The editor exposes understandable layout controls without making the structural panel grid unintelligible."
+      ]
+    }
+  ],
+  "evidenceContract": {
+    "retainPerJourney": [
+      "copied source inputs and SHA-256 checks",
+      "analysis JSON, canonical plan, and every manual correction",
+      "readable author and plugin previews plus their confirmation hashes",
+      "generated source manifest, build log, packed CLI tarball, plugin ZIP, and hashes",
+      "command and environment logs, diagnostics, proof receipt, editor save/reopen screenshot, and frontend screenshot"
+    ],
+    "sharedExercises": [
+      "two pattern instances where overrides are declared, canonical update, and individual reset",
+      "one supported existing-plugin integration",
+      "one later generated-source change that preserves user-edited content and refuses incompatible structural regeneration"
+    ],
+    "unrunState": "Every item is pending until its retained receipt exists. A missing, blocked, or failed gate is not a pass."
+  },
+  "ownerAcceptance": {
+    "status": "required",
+    "humanOnlyDecisions": [
+      "authorise the exact preview confirmation hashes and any existing-plugin replacement paths",
+      "judge visual fidelity and editing feel on the prepared WordPress target",
+      "perform the retained manual accessibility review"
+    ]
+  }
+}

--- a/acceptance/0.9-testing/inputs.json
+++ b/acceptance/0.9-testing/inputs.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
-  "candidateRevision": "58dc3b973313c75563610a6ea5cf532c98efa83b",
+  "preparedAgainstRevision": "3cb0d50292a59af1c0b77a3aa14c093516651cae",
+  "candidateRevisionRequirement": "The prepared candidate must record its exact Git revision and packed tarball SHA-256 in its immutable evidence receipt. Do not reuse this preparation revision as a release-candidate claim.",
   "status": "prepared-not-run",
   "purpose": "Two repository-controlled inputs for the 0.9 owner-acceptance journeys. This manifest is not a benchmark receipt and does not claim real-project coverage.",
   "sourceProvenance": {

--- a/acceptance/0.9-testing/prepare-inputs.mjs
+++ b/acceptance/0.9-testing/prepare-inputs.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { copyFile, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const directory = dirname(fileURLToPath(import.meta.url));
+const repository = resolve(directory, '../..');
+const manifestPath = resolve(directory, 'inputs.json');
+const manifestBytes = await readFile(manifestPath);
+const manifest = JSON.parse(manifestBytes.toString('utf8'));
+const arguments_ = process.argv.slice(2);
+const check = arguments_.includes('--check');
+const outputIndex = arguments_.indexOf('--output');
+const revisionIndex = arguments_.indexOf('--candidate-revision');
+
+if (check && arguments_.length !== 1) usage();
+if (!check && (outputIndex < 0 || revisionIndex < 0 || outputIndex + 1 >= arguments_.length || revisionIndex + 1 >= arguments_.length || arguments_.length !== 4)) usage();
+
+const files = [];
+for (const journey of manifest.journeys) {
+  for (const input of [journey.source, ...journey.dependencies]) {
+    const declaredPath = input.html ?? input.path;
+    const source = resolve(directory, declaredPath);
+    if (!source.startsWith(`${repository}/`)) throw new Error(`Input escapes the repository: ${declaredPath}`);
+    const digest = `sha256:${hash(await readFile(source))}`;
+    if (digest !== input.sha256) throw new Error(`${journey.id}: expected ${input.sha256}, got ${digest} for ${declaredPath}`);
+    files.push({ journey: journey.id, source, declaredPath, sha256: digest });
+  }
+}
+
+if (check) {
+  console.log(`checked ${files.length} acceptance input file(s)`);
+  process.exit(0);
+}
+
+const output = resolve(arguments_[outputIndex + 1]);
+if (output === repository || output.startsWith(`${repository}/`)) throw new Error('Output must not be inside the repository.');
+try {
+  await stat(output);
+  throw new Error(`Refusing to overwrite existing output: ${output}`);
+} catch (error) {
+  if (!(error && typeof error === 'object' && error.code === 'ENOENT')) throw error;
+}
+
+await mkdir(output);
+const copied = [];
+for (const file of files) {
+  const staged = resolve(output, file.journey, relative(repository, file.source));
+  await mkdir(dirname(staged), { recursive: true });
+  await copyFile(file.source, staged);
+  copied.push({
+    journey: file.journey,
+    source: file.declaredPath,
+    staged: relative(output, staged),
+    sha256: file.sha256,
+  });
+}
+
+const receipt = {
+  version: 1,
+  status: 'staged-not-run',
+  candidateRevision: arguments_[revisionIndex + 1],
+  inputsManifestSha256: `sha256:${hash(manifestBytes)}`,
+  files: copied,
+  note: 'Staging preserves reviewed source bytes only. It does not analyse, generate, build, install, or prove a block.',
+};
+await writeFile(resolve(output, 'input-receipt.json'), `${JSON.stringify(receipt, null, 2)}\n`);
+console.log(`staged ${copied.length} input file(s) in ${output}`);
+
+function hash(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function usage() {
+  throw new Error('Usage: prepare-inputs.mjs --check | --output <new-directory> --candidate-revision <full-git-sha>');
+}

--- a/release/0.9-testing/README.md
+++ b/release/0.9-testing/README.md
@@ -104,6 +104,12 @@ npm run authoring:prove -- --plans /path/to/saved-plans
 The runner never creates plans by calling a model or copying expected answers. A
 later scored benchmark needs its own retained receipt.
 
+Issue #54's two owner-acceptance inputs live in
+[`../../acceptance/0.9-testing/`](../../acceptance/0.9-testing/). They are
+repository-controlled preparation fixtures, not benchmark rows or completed
+real-project evidence. Their candidate index keeps the human visual,
+editing-feel, and manual-accessibility decisions explicitly required.
+
 The release checker builds its activation ZIP through the production compiler and
 standalone-plugin builder, then uses the built-in WordPress proof runner. ZIP
 activation is a narrower claim than a passing full proof.


### PR DESCRIPTION
## Summary

- stage two repository-controlled acceptance inputs with pinned hashes
- add a safe, non-overwriting input preparation harness
- document the packed-candidate workflow, retained evidence, and owner-only decisions

## Verification

- `node --check acceptance/0.9-testing/prepare-inputs.mjs`
- `node acceptance/0.9-testing/prepare-inputs.mjs --check`
- JSON parse and four input SHA-256 checks
- local Markdown link validation
- `git diff --check`

## Boundary

No benchmark, browser, WordPress proof, or publication was run. This prepares issue #54 but does not claim the owner acceptance journeys have passed; confirmation, runtime evidence, and human review remain pending.

Refs #54