### PR TITLE
Tests: replace implementation-text assertions with focused behaviour checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,65 @@ On GitHub Actions, the separate WordPress proof job uploads a
 `evidence/sha256` objects, so reviewers can inspect the WordPress 7.1 lifecycle evidence from
 the relevant build without committing environment-specific run output.
 
+### Testing workflow
+
+For ordinary changes, run the focused affected tests first:
+
+```sh
+npx vitest run <affected files>
+```
+
+For changes to proof startup or publication recovery, run:
+
+```sh
+npx vitest run test/proof-control-setup.test.ts test/proof.test.ts test/publication.test.ts test/publication.public-api.test.ts
+npm run typecheck
+```
+
+`npm run verify` remains the required repository gate. Run `npm run build && npm run test:package`
+when changing exports, packed files, dependency pins, or consumer behavior. Run
+`npm run test:proof:wordpress` for proof-runner, browser, emitted-editor layout, persistence,
+or pattern changes; it requires Docker. Run the opt-in `npm run test:proof:mutations` only when
+detector wiring changes, and run the existing release check only for release candidates or release
+automation. Do not relax the visible mutation skips, runtime-proof gates, thresholds, or the
+intentional `fileParallelism: false` Gutenberg serialization.
+
+The following inventory makes the focused checks auditable:
+
+- The control-startup helper replaces VM extraction and script-order assertions. Its test proves a
+  writable `.block-runner-proof-stage`, retained existing ZIPs before startup, and that an
+  incompatible path is preserved without invoking startup.
+- A proof-runner command test replaces the staged-container-directory literal check: `wp plugin
+  install` receives a byte-identical ZIP beneath `/var/www/html/wp-content/block-runner-proof/`,
+  never an uploads path. The exact `proof/wp-env.json` mapping remains a schema contract.
+- The `wp_upload_bits`, upload-error, retained-byte hash, and no-direct-write checks remain the
+  media byte contract: successful WordPress execution cannot deterministically inject both upload
+  failure and corrupt retained bytes.
+- The one-command staging-failure receipt test remains. The former receipt-index source-order
+  assertion is protected by the failed-full-proof content-addressed readable-receipt case in
+  `test/proof.test.ts`. Named CI and release artifact-upload checks retain their `if: always()`
+  and `node_modules` exclusions.
+- The `src/publication.ts` call-site assertions were removed because the shared lifecycle matrix in
+  `test/publication.test.ts` covers interruption, reconciliation, pending-file races,
+  corrupt/missing/linked staging, and final verification. Authoring and plugin adapters retain
+  their recovery, approval, conflict, and user-visible-error coverage; the public cleanup guard
+  retains its recursive-deletion prohibition and guarded-trash fallback.
+
+Unchanged behavioral coverage includes `authoring.runtime.test.ts` for emitted-component layout
+and v1-to-v2 content persistence; `proof-real-wordpress.test.ts` and
+`proof-pattern-overrides.test.ts` for native editor layout and isolated pattern instances;
+`plugin.profile.test.ts` plus `test:package` for packaged assets;
+`authoring.destination.test.ts` and `registered-block.workflow.test.ts` for confirmation; the
+shared publication matrix plus adapter suites for concurrent edits and interruption;
+`proof-visual-baselines.test.ts` for reviewed bytes; and the visibly skipped mutation suite for
+real-ZIP detector checks.
+
+Timing is recorded only as comparable observed samples, never as a general speed claim. The
+baseline is `npm test` at head `631a13bd` with the same lockfile on the same Mini: started
+`2026-09-06T05:08:49.668Z`, finished `2026-09-06T05:14:44.746Z`, duration `355.078s`. Record the
+single required #52 Foundry-gate sample beside it with its exact tested head, command, start time,
+exit time, and duration; do not compare unrelated CI lanes, machines, or workloads.
+
 ## Media Resolution
 
 A `<img src="hero.jpg">` in generated HTML is just a URL, but WordPress image and cover blocks

--- a/scripts/collect-native-heading-control.mjs
+++ b/scripts/collect-native-heading-control.mjs
@@ -12,12 +12,12 @@
  * validates the retained JSON and its hash before using it.
  */
 import { createHash } from 'node:crypto';
-import { constants as fsConstants } from 'node:fs';
 import { execFile } from 'node:child_process';
-import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import { promisify } from 'node:util';
+import { startWithPreparedStageMount } from './proof-control-startup.mjs';
 
 const execFileAsync = promisify(execFile);
 const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
@@ -59,8 +59,10 @@ await mkdir(outputDirectory, { recursive: true });
 
 try {
   const startedAt = new Date().toISOString();
-  await prepareStageMount();
-  const start = await runCommand('npx', ['--no-install', 'wp-env', `--config=${WP_ENV_CONFIG}`, 'start'], 'start');
+  const start = await startWithPreparedStageMount({
+    root: ROOT,
+    start: () => runCommand('npx', ['--no-install', 'wp-env', `--config=${WP_ENV_CONFIG}`, 'start'], 'start'),
+  });
   if (start.exitCode !== 0) throw new Error(`Pinned WordPress 7.1 environment did not start (exit ${start.exitCode}).`);
 
   const before = await observeVersion('before');
@@ -166,14 +168,6 @@ try {
   if (!keepEnvironment) {
     await runCommand('npx', ['--no-install', 'wp-env', `--config=${WP_ENV_CONFIG}`, 'stop'], 'stop');
   }
-}
-
-async function prepareStageMount() {
-  // Create the later ZIP bind mount as the host user before Docker can create
-  // a root-owned directory on Linux. Never repair existing permissions silently.
-  const directory = path.join(ROOT, '.block-runner-proof-stage');
-  await mkdir(directory, { recursive: true });
-  await access(directory, fsConstants.W_OK);
 }
 
 function valueFor(flag) {

--- a/scripts/proof-control-startup.d.mts
+++ b/scripts/proof-control-startup.d.mts
@@ -1,0 +1,6 @@
+export interface ProofControlStartupOptions<T> {
+  root: string;
+  start: () => T | Promise<T>;
+}
+
+export function startWithPreparedStageMount<T>(options: ProofControlStartupOptions<T>): Promise<Awaited<T>>;

--- a/scripts/proof-control-startup.mjs
+++ b/scripts/proof-control-startup.mjs
@@ -1,0 +1,15 @@
+import { constants as fsConstants } from 'node:fs';
+import { access, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Prepare the host-owned wp-env bind mount before asking Docker to start.
+ * Keeping the prerequisite and start request together prevents a fresh Linux
+ * Docker mount from creating a root-owned directory for the host user.
+ */
+export async function startWithPreparedStageMount({ root, start }) {
+  const directory = path.join(root, '.block-runner-proof-stage');
+  await mkdir(directory, { recursive: true });
+  await access(directory, fsConstants.W_OK);
+  return start();
+}

--- a/test/proof-control-setup.test.ts
+++ b/test/proof-control-setup.test.ts
@@ -1,47 +1,97 @@
 import { constants as fsConstants, readFileSync } from 'node:fs';
-import { access, mkdir, mkdtemp, readFile, rename, stat, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdir, mkdtemp, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { runInNewContext } from 'node:vm';
 import { describe, expect, it } from 'vitest';
 import { runProof } from '../src/proof/runner.js';
-
-const collector = readFileSync(new URL('../scripts/collect-native-heading-control.mjs', import.meta.url), 'utf8');
-const begin = collector.indexOf('async function prepareStageMount(');
-const end = collector.indexOf('\nfunction ', begin + 1);
-const prepare = (root: string) => (runInNewContext(`(${collector.slice(begin, end)})`, {
-  ROOT: root, path, mkdir, access, fsConstants,
-}) as () => Promise<void>)();
+import { startWithPreparedStageMount } from '../scripts/proof-control-startup.mjs';
 
 describe('WordPress control startup and retained failures', () => {
-  it('keeps Docker ZIP staging outside WordPress media uploads', () => {
+  it('keeps the wp-env mount schema and media byte contract outside WordPress uploads', () => {
     const config = JSON.parse(readFileSync(new URL('../proof/wp-env.json', import.meta.url), 'utf8'));
     expect(config.mappings).toEqual({ 'wp-content/block-runner-proof': '.block-runner-proof-stage' });
     const runner = readFileSync(new URL('../src/proof/runner.ts', import.meta.url), 'utf8');
-    expect(runner).toContain("const stagedZipContainerDirectory = '/var/www/html/wp-content/block-runner-proof'");
+    // These checks intentionally guard WordPress upload failures and retained-byte
+    // corruption, which a successful runtime install cannot deterministically inject.
     expect(runner).toContain('wp_upload_bits($filename, null, $png)');
     expect(runner).toContain("if (!empty($upload['error']))");
     expect(runner).toContain("hash_file('sha256', $file) !== hash('sha256', $png)");
     expect(runner).not.toContain('file_put_contents($file, $png)');
   });
 
-  it('creates the writable host staging directory before Docker startup', async () => {
+  it('makes host staging writable and preserves ZIPs before starting Docker', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'block-runner-control-stage-'));
-    await prepare(root);
     const directory = path.join(root, '.block-runner-proof-stage');
-    expect((await stat(directory)).isDirectory()).toBe(true);
+    await startWithPreparedStageMount({ root, start: async () => {
+      expect((await stat(directory)).isDirectory()).toBe(true);
+      await access(directory, fsConstants.W_OK);
+      await writeFile(path.join(directory, 'startup-write-probe'), 'writable');
+    } });
     await writeFile(path.join(directory, 'existing.zip'), 'retained');
-    await prepare(root);
-    expect(await readFile(path.join(directory, 'existing.zip'), 'utf8')).toBe('retained');
-    expect(collector.indexOf('await prepareStageMount();')).toBeLessThan(collector.indexOf("const start = await runCommand('npx'"));
+    let observed: string | undefined;
+    await startWithPreparedStageMount({ root, start: async () => {
+      await access(directory, fsConstants.W_OK);
+      observed = await readFile(path.join(directory, 'existing.zip'), 'utf8');
+    } });
+    expect(observed).toBe('retained');
   });
 
-  it('refuses an incompatible existing stage path instead of replacing it', async () => {
+  it('rejects a non-writable existing stage directory without starting Docker', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'block-runner-control-stage-read-only-'));
+    const directory = path.join(root, '.block-runner-proof-stage');
+    await mkdir(directory);
+    await chmod(directory, 0o555);
+    let started = false;
+    try {
+      await expect(startWithPreparedStageMount({ root, start: async () => { started = true; } })).rejects.toThrow();
+      expect(started).toBe(false);
+    } finally {
+      await chmod(directory, 0o755);
+    }
+  });
+
+  it('preserves an incompatible existing stage path and never starts Docker', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'block-runner-control-stage-file-'));
     const file = path.join(root, '.block-runner-proof-stage');
     await writeFile(file, 'preserve');
-    await expect(prepare(root)).rejects.toThrow();
+    let started = false;
+    await expect(startWithPreparedStageMount({ root, start: async () => { started = true; } })).rejects.toThrow();
     expect(await readFile(file, 'utf8')).toBe('preserve');
+    expect(started).toBe(false);
+  });
+
+  it('installs a byte-identical staged ZIP through the non-media wp-env mount', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'block-runner-staged-zip-'));
+    const zip = path.join(root, 'candidate.zip');
+    const input = path.join(root, 'input.json');
+    const zipBytes = Buffer.from(`zip-${root}`);
+    await Promise.all([writeFile(zip, zipBytes), writeFile(input, '{}')]);
+    const commands: Array<{ command: string; args: string[] }> = [];
+    let stagedHostPath: string | undefined;
+    try {
+      await runProof({
+        profile: 'runtime', pluginZip: zip, inputPath: input, outputDir: path.join(root, 'proof'),
+        fixture: { blockName: 'test/fixture' },
+        commandRunner: async (command, args) => {
+          commands.push({ command, args: [...args] });
+          const installAt = args.indexOf('install');
+          if (command === 'npx' && installAt >= 0 && args[installAt - 1] === 'plugin') {
+            stagedHostPath = path.join(process.cwd(), '.block-runner-proof-stage', path.basename(args[installAt + 1]!));
+            return { command, args: [...args], exitCode: 1, stdout: '', stderr: 'test adapter stops after observing installation' };
+          }
+          return { command, args: [...args], exitCode: 0, stdout: '', stderr: '' };
+        },
+      });
+      const install = commands.find(({ command, args }) => command === 'npx' && args.includes('plugin') && args.includes('install'));
+      expect(install).toBeDefined();
+      const stagedContainerPath = install!.args[install!.args.indexOf('install') + 1]!;
+      expect(stagedContainerPath).toMatch(/^\/var\/www\/html\/wp-content\/block-runner-proof\/[^/]+\.zip$/);
+      expect(stagedContainerPath).not.toContain('uploads');
+      expect(stagedHostPath).toBeDefined();
+      expect(await readFile(stagedHostPath!)).toEqual(zipBytes);
+    } finally {
+      if (stagedHostPath) await unlink(stagedHostPath).catch(() => undefined);
+    }
   });
 
   it('retains one staging failure without repeatedly probing Docker', async () => {
@@ -66,14 +116,16 @@ describe('WordPress control startup and retained failures', () => {
     expect(result.ok).toBe(false);
   });
 
-  it('writes the receipt index before asserting the observed runtime', () => {
-    const testSource = readFileSync(new URL('./proof-real-wordpress.test.ts', import.meta.url), 'utf8');
-    expect(testSource.indexOf("path.join(outputDir, 'receipt-index.json')"))
-      .toBeLessThan(testSource.indexOf('expect(result.receipt.environment.wordpress.version)'));
-    for (const workflow of ['ci.yml', 'release.yml']) {
+  it('retains named artifact uploads on failure without node_modules', () => {
+    const contracts = [
+      ['ci.yml', 'Upload WordPress 7.1 pattern-overrides receipt'],
+      ['release.yml', 'Retain release receipts'],
+    ] as const;
+    for (const [workflow, stepName] of contracts) {
       const yaml = readFileSync(new URL(`../.github/workflows/${workflow}`, import.meta.url), 'utf8');
-      expect(yaml).toContain('/**/node_modules/**');
-      expect(yaml).toContain('if: always()');
+      const step = yaml.slice(yaml.indexOf(`- name: ${stepName}`), yaml.indexOf('\n      - name:', yaml.indexOf(`- name: ${stepName}`) + 1));
+      expect(step).toContain('if: always()');
+      expect(step).toContain('/**/node_modules/**');
     }
   });
 });

--- a/test/publication.public-api.test.ts
+++ b/test/publication.public-api.test.ts
@@ -19,10 +19,7 @@ it('retains the guarded public API while adding recovery entry points', () => {
 
 it('does not introduce permanent recursive deletion into publication cleanup', async () => {
   const source = await readFile(new URL('../src/plugin/profile.ts', import.meta.url), 'utf8');
-  const mechanics = await readFile(new URL('../src/publication.ts', import.meta.url), 'utf8');
   expect(source).not.toMatch(/\b(?:rm|rmdir|rmSync|rmdirSync)\s*\(/);
   expect(source).toContain("execFileAsync('trash', [stageDirectory])");
   expect(source).toContain("path.join(homedir(), '.Trash')");
-  expect(mechanics).toContain('publishStagedFile');
-  expect(mechanics).toContain('verifyPublicationTargets');
 });


### PR DESCRIPTION
## Problem
Parts of the suite inspect source snippets and function ordering instead of observing the behaviour they protect. These checks make harmless refactoring expensive. The recent successful CI run also spent roughly 6–8.5 minutes in each Node test suite, so repeating every layer for each small change is costly. Closes #52.

## Solution
Implementation details and verification evidence are recorded separately below.

## Diff

+164 −41 · 6 files

```diff
 File changes (line counts, not file creation/deletion)
+ "README.md" # 59 lines added
- "scripts/collect-native-heading-control.mjs" # 12 lines removed
+ "scripts/collect-native-heading-control.mjs" # 6 lines added
+ "scripts/proof-control-startup.d.mts" # 6 lines added
+ "scripts/proof-control-startup.mjs" # 15 lines added
- "test/proof-control-setup.test.ts" # 26 lines removed
+ "test/proof-control-setup.test.ts" # 78 lines added
- "test/publication.public-api.test.ts" # 3 lines removed
```

## Testing & verification
- **Local run** — `npm run typecheck` → pass; environment: node@0a49bc370fca; revision: `cd457b1ad865`.
- **Local run** — `npm run test` → pass; environment: node@0a49bc370fca; revision: `cd457b1ad865`.
- **Local run** — `npm run build` → pass; environment: node@0a49bc370fca; revision: `cd457b1ad865`.
- **Local run** — `npm run typecheck` → pass; environment: node@0a49bc370fca; revision: `8968ef9ad7ad`.
- **Local run** — `npm run test` → pass; environment: node@0a49bc370fca; revision: `8968ef9ad7ad`.
- **Local run** — `npm run build` → pass; environment: node@0a49bc370fca; revision: `8968ef9ad7ad`.
- **Issue checks** — none recorded by the factory.
- CI: passed (5/5).
- **Not run** — no live/manual verification; this Foundry run has no browser.

**Delivery status:** running.

## Effective verification posture

This public open source repository uses relevant functional checks and pragmatic runtime proof.
Visual or browser evidence was selected: explicit issue acceptance requests browser or visual evidence; execution: not_configured.
Additional scrutiny: destructive or integrity-affecting behaviour requires safety and recovery evidence.

## QA evidence

QA: not verified — no recipe configured
Required verification was unavailable: no capture recipe or prior verification receipt was available.
Required browser or customer-workflow proof is unavailable; this pull request remains a draft.

## Risk / rollout
Small, targeted change — see the diff for the affected paths.


---
*Built by 🪺 Rookery · flight #175 · 46m40s · 2 passes · gpt-5.6-terra·medium*