### PR TITLE
Tests: separate consumer archive checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
       - run: npm run build
       - name: Verify basic and proof-enabled packed consumers
         run: npm run test:package
+      - name: Verify clean consumer archive builds
+        run: npm run test:consumer
 
   wordpress-proof:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -515,13 +515,23 @@ npx vitest run dev/test/proof-control-setup.test.ts dev/test/proof.test.ts dev/t
 npm run typecheck
 ```
 
-`npm run verify` remains the required repository gate. Run `npm run build && npm run test:package`
-when changing exports, packed files, dependency pins, or consumer behavior. Run
+`npm run verify` remains the required repository gate. It runs the deterministic repository
+suite. Run `npm run test:consumer` separately to build the clean standalone release archive and
+the native style-adapter fixture; it needs npm, `unzip`, and enough time for an isolated
+`npm ci` and two ZIP builds. Run `npm run build && npm run test:package`
+when changing exports, packed files, dependency pins, or consumer behavior. The full CI and
+release matrix run both repository and consumer suites. Run
 `npm run test:proof:wordpress` for proof-runner, browser, emitted-editor layout, persistence,
 or pattern changes; it requires Docker. Run the opt-in `npm run test:proof:mutations` only when
 detector wiring changes, and run the existing release check only for release candidates or release
 automation. Do not relax the visible mutation skips, runtime-proof gates, thresholds, or the
 intentional `fileParallelism: false` Gutenberg serialization.
+
+The consumer suite owns these archive assertions: `standalone consumer release archive > resolves,
+clean-installs, builds, and inspects the actual release archive` in
+`plugin.consumer.test.ts`, and `native style adapter proof fixture > retains and pins the public
+utility hero package with authored image sizing` in
+`proof-native-style-adapter-builder.test.ts`.
 
 ## Media Resolution
 

--- a/dev/test/plugin.consumer.test.ts
+++ b/dev/test/plugin.consumer.test.ts
@@ -1,0 +1,72 @@
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+import { compileRegisteredBlock, registeredBlockFontFamilyPrefix } from '../../src/authoring/generate.js';
+import { PROOF_IMAGE_BASE64 } from '../../src/proof/fixture-image.js';
+import { assertStandaloneZipEntries, npmEnvironmentForGeneratedPlugin, planExistingPluginOutput, planStandalonePluginOutput, writePluginOutput } from '../../src/plugin/profile.js';
+
+const execFileAsync = promisify(execFile);
+
+describe('standalone consumer release archive', () => {
+  it('resolves, clean-installs, builds, and inspects the actual release archive', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'block-runner-release-'));
+    const output = path.join(root, 'notice-plugin');
+    const image = Buffer.from(PROOF_IMAGE_BASE64, 'base64');
+    const sourceImage = path.join(root, 'photo.png'); await writeFile(sourceImage, image);
+    const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40"><path d="M0 0h80v40H0z" fill="#123456"/></svg>');
+    const sourceSvg = path.join(root, 'logo.svg'); await writeFile(sourceSvg, svg);
+    const sourceFont = path.resolve('dev/test/fixtures/fonts/IBMPlexMono-Regular.woff2');
+    const font = await readFile(sourceFont);
+    const fontNotice = await readFile(path.resolve('dev/test/fixtures/fonts/OFL.txt'), 'utf8');
+    const fontFamily = `${registeredBlockFontFamilyPrefix('acme/notice')}body`;
+    const generated = compileRegisteredBlock({
+      version: 1, generatorVersion: '0.9.0', target: { name: 'acme/notice', title: 'Notice' },
+      structure: [{ block: 'core/group', attributes: { className: 'card' }, children: [{ block: 'core/paragraph', attributes: { content: 'Packaged native content' } }, { id: 'logo', block: 'core/image', attributes: { alt: 'Logo', className: 'logo' } }] }], fields: [], locking: { mode: 'contentOnly' }, pattern: { ready: false, overrides: [] },
+      styles: { strategy: 'mixed', outcomes: [], fonts: [{ assetId: 'body-font', family: fontFamily, fontWeight: '400', fontDisplay: 'swap' }], rules: [
+        { kind: 'style', selector: '.card', declarations: [{ property: 'font-family', value: `"${fontFamily}", monospace` }] },
+        { kind: 'style', selector: '.card', declarations: [{ property: 'background-image', value: 'url("./assets/photo.png")' }] },
+        { kind: 'style', selector: '.logo', declarations: [{ property: 'mask-image', value: 'url("./assets/logo.svg")' }] },
+        { kind: 'conditional', name: 'media', prelude: '(min-width: 48rem)', rules: [{ kind: 'style', selector: '.card:hover', declarations: [{ property: 'transform', value: 'translateY(-2px)' }] }] },
+      ], editorRules: [{ kind: 'style', selector: '.card:focus-within', declarations: [{ property: 'outline', value: '2px solid blue' }] }] },
+      assets: [{ id: 'photo', source: sourceImage, status: 'ready', destination: 'assets/photo.png', sha256: createHash('sha256').update(image).digest('hex') }, { id: 'logo', source: sourceSvg, status: 'ready', destination: 'assets/logo.svg', sha256: createHash('sha256').update(svg).digest('hex'), uses: [{ node: 'logo', attribute: 'url' }] }, { id: 'body-font', source: sourceFont, kind: 'font', status: 'ready', destination: 'assets/body.woff2', sha256: createHash('sha256').update(font).digest('hex'), fontLicense: { ownership: 'IBM Corp.', license: 'OFL-1.1', notice: fontNotice } }], files: [], warnings: [],
+    });
+    const plan = await planStandalonePluginOutput(output, { name: 'acme/notice', files: Object.fromEntries([...generated.files, ...generated.assets].map((file) => [file.path, file.content])) });
+    await writePluginOutput(plan);
+    const lock = JSON.parse(await readFile(path.join(output, 'package-lock.json'), 'utf8')) as { packages: Record<string, { version?: string }> };
+    expect(lock.packages['node_modules/@wordpress/scripts']?.version).toBe('34.2.0');
+    await expect(stat(path.join(output, 'node_modules'))).rejects.toThrow();
+    const npmEnvironment = await npmEnvironmentForGeneratedPlugin(output);
+    await execFileAsync('npm', ['ci', '--include=dev', '--no-audit', '--no-fund'], { cwd: output, timeout: 120_000, env: npmEnvironment });
+    await execFileAsync('npm', ['run', 'zip'], { cwd: output, timeout: 120_000, env: { ...npmEnvironment, NODE_ENV: 'production' } });
+    const archive = path.join(output, 'acme-notice.zip'); expect(await stat(archive)).toBeTruthy();
+    await execFileAsync('npm', ['run', 'test:zip', '--', archive], { cwd: output, timeout: 30_000 });
+    const entries = (await execFileAsync('unzip', ['-Z1', archive])).stdout.split(/\r?\n/).filter(Boolean);
+    expect(() => assertStandaloneZipEntries(entries, 'notice', ['index.js', 'style-index.css', 'index.css'])).not.toThrow();
+    const archiveBytes = async (entry: string): Promise<Buffer> => (await execFileAsync('unzip', ['-p', archive, entry], { encoding: 'buffer', timeout: 10_000 })).stdout;
+    const sharedCssPath = entries.find((entry) => entry.endsWith('/blocks/notice/style-index.css'))!;
+    const editorCssPath = entries.find((entry) => entry.endsWith('/blocks/notice/index.css'))!;
+    const css = (await archiveBytes(sharedCssPath)).toString('utf8');
+    expect(css).toContain(':where(.wp-block-acme-notice) .card'); expect(css).toMatch(/@media\s*\(min-width:\s*48rem\)/); expect(css).toContain('translateY(-2px)'); expect(css).not.toContain('./assets/photo.png'); expect(css).not.toContain('focus-within'); expect(css).toContain('@font-face'); expect(css).toContain(fontFamily); expect(css).not.toContain(sourceFont);
+    const noticePath = entries.find((entry) => entry.endsWith('/blocks/notice/font-licenses.txt')); expect(noticePath).toBeDefined();
+    const notice = (await archiveBytes(noticePath!)).toString('utf8'); expect(notice).toContain('Copyright © 2017 IBM Corp.'); expect(notice).toContain('SIL OPEN FONT LICENSE Version 1.1'); expect(notice).toContain('OTHER DEALINGS IN THE FONT SOFTWARE.'); expect(notice).not.toContain(sourceFont);
+    const fonts = entries.filter((entry) => /\/build\/.*\.woff2$/.test(entry)); expect(fonts).toHaveLength(1); expect(await archiveBytes(fonts[0]!)).toEqual(font); expect(css).toContain(path.basename(fonts[0]!)); expect((await archiveBytes(editorCssPath)).toString('utf8')).not.toContain('@font-face'); expect((await archiveBytes(editorCssPath)).toString('utf8')).toContain('.card:focus-within');
+    const images = entries.filter((entry) => /\/build\/images\/.*\.png$/.test(entry)); expect(images).toHaveLength(1); expect(await archiveBytes(images[0]!)).toEqual(image); expect(css).toContain(path.basename(images[0]!)); expect(entries.some((entry) => entry.endsWith('.map'))).toBe(false);
+    const svgData = /data:image\/svg\+xml(?:;charset=[^;,]+)?(?:;base64)?,[^)"'\s]+/.exec(css)?.[0]; expect(svgData).toBeDefined();
+    const [header, payload] = svgData!.split(',', 2); const cssSvg = header!.includes(';base64') ? Buffer.from(payload!, 'base64') : Buffer.from(decodeURIComponent(payload!)); expect(cssSvg.toString()).toContain('viewBox="0 0 80 40"'); expect(cssSvg.toString()).toContain('#123456');
+    const script = (await archiveBytes(entries.find((entry) => entry.endsWith('/blocks/notice/index.js'))!)).toString('utf8');
+    const svgFiles = entries.filter((entry) => /\/build\/.*\.svg$/.test(entry)); expect(svgFiles).toHaveLength(1); expect(await archiveBytes(svgFiles[0]!)).toEqual(svg); expect(script).toContain(path.basename(svgFiles[0]!)); expect(script).not.toContain('data:image/svg+xml'); expect(script).not.toContain('./assets/logo.svg');
+    const existingSource = new Map(await Promise.all([...generated.files, ...generated.assets].map(async (file) => [file.path, await readFile(path.join(output, 'src/blocks/notice', file.path))] as const)));
+    const addition = compileRegisteredBlock({ version: 1, generatorVersion: '0.9.0', target: { name: 'acme/second-notice', title: 'Second notice' }, structure: [{ id: 'message', block: 'core/paragraph', attributes: { content: 'An independently registered second block.' } }], fields: [{ id: 'message', node: 'message', attribute: 'content', label: 'Message', mode: 'editable' }], locking: { mode: 'contentOnly' }, styles: { strategy: 'native', outcomes: [] }, pattern: { ready: false, overrides: [] }, assets: [], files: [], warnings: [] });
+    const integration = await planExistingPluginOutput(output, { name: 'acme/second-notice', files: Object.fromEntries(addition.files.map((file) => [file.path, file.content])) }); expect(integration.mode).toBe('existing');
+    await writePluginOutput(integration, { authorizedReplacements: integration.touchedFiles.filter((file) => file.operation === 'modify').map((file) => file.path) });
+    for (const [relative, bytes] of existingSource) expect(await readFile(path.join(output, 'src/blocks/notice', relative))).toEqual(bytes);
+    await execFileAsync('npm', ['run', 'zip'], { cwd: output, timeout: 120_000, env: { ...npmEnvironment, NODE_ENV: 'production' } }); await execFileAsync('npm', ['run', 'test:zip', '--', archive], { cwd: output, timeout: 30_000 });
+    const rebuiltEntries = (await execFileAsync('unzip', ['-Z1', archive])).stdout.split(/\r?\n/).filter(Boolean);
+    for (const leaf of ['notice', 'second-notice']) { const metadataEntry = rebuiltEntries.find((entry) => entry.endsWith(`/build/blocks/${leaf}/block.json`)); expect(metadataEntry).toBeDefined(); expect(JSON.parse((await archiveBytes(metadataEntry!)).toString('utf8')).name).toBe(`acme/${leaf}`); }
+    const manifest = await readFile(path.join(output, 'build/blocks-manifest.php'), 'utf8'); expect(manifest).toContain("'notice'"); expect(manifest).toContain("'second-notice'");
+  }, 300_000);
+});

--- a/dev/test/plugin.profile.test.ts
+++ b/dev/test/plugin.profile.test.ts
@@ -1,18 +1,14 @@
 import { execFile } from 'node:child_process';
-import { createHash } from 'node:crypto';
 import { chmod, mkdtemp, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { describe, expect, it } from 'vitest';
-import { compileRegisteredBlock, registeredBlockFontFamilyPrefix } from '../../src/authoring/generate.js';
-import { PROOF_IMAGE_BASE64 } from '../../src/proof/fixture-image.js';
 import {
   assertStandaloneZipEntries,
   detectWpScriptsPlugin,
   planExistingPluginOutput,
   planStandalonePluginOutput,
-  npmEnvironmentForGeneratedPlugin,
   PublicationInterruptedError,
   removeMatchingAllowScriptsProjection,
   retryPluginPublication,
@@ -382,152 +378,6 @@ describe('standalone plugin profile', () => {
     ], 'notice')).toThrow('runtime allowlist');
   });
 
-  it('resolves, clean-installs, builds, and inspects the actual release archive', async () => {
-    const root = await mkdtemp(path.join(tmpdir(), 'block-runner-release-'));
-    const output = path.join(root, 'notice-plugin');
-    const image = Buffer.from(PROOF_IMAGE_BASE64, 'base64');
-    const sourceImage = path.join(root, 'photo.png');
-    await writeFile(sourceImage, image);
-    const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40"><path d="M0 0h80v40H0z" fill="#123456"/></svg>');
-    const sourceSvg = path.join(root, 'logo.svg');
-    await writeFile(sourceSvg, svg);
-    const sourceFont = path.resolve('dev/test/fixtures/fonts/IBMPlexMono-Regular.woff2');
-    const font = await readFile(sourceFont);
-    const fontNotice = await readFile(path.resolve('dev/test/fixtures/fonts/OFL.txt'), 'utf8');
-    const fontFamily = `${registeredBlockFontFamilyPrefix('acme/notice')}body`;
-    // Exercise the public compiler, not the small hand-written source stub used by profile unit tests.
-    const generated = compileRegisteredBlock({
-      version: 1, generatorVersion: '0.9.0', target: { name: 'acme/notice', title: 'Notice' },
-      structure: [{ block: 'core/group', attributes: { className: 'card' }, children: [
-        { block: 'core/paragraph', attributes: { content: 'Packaged native content' } },
-        { id: 'logo', block: 'core/image', attributes: { alt: 'Logo', className: 'logo' } },
-      ] }],
-      fields: [], locking: { mode: 'contentOnly' }, pattern: { ready: false, overrides: [] },
-      styles: { strategy: 'mixed', outcomes: [],
-        fonts: [{ assetId: 'body-font', family: fontFamily, fontWeight: '400', fontDisplay: 'swap' }], rules: [
-        { kind: 'style', selector: '.card', declarations: [{ property: 'font-family', value: `"${fontFamily}", monospace` }] },
-        { kind: 'style', selector: '.card', declarations: [{ property: 'background-image', value: 'url("./assets/photo.png")' }] },
-        { kind: 'style', selector: '.logo', declarations: [{ property: 'mask-image', value: 'url("./assets/logo.svg")' }] },
-        { kind: 'conditional', name: 'media', prelude: '(min-width: 48rem)', rules: [
-          { kind: 'style', selector: '.card:hover', declarations: [{ property: 'transform', value: 'translateY(-2px)' }] },
-        ] },
-      ], editorRules: [
-        { kind: 'style', selector: '.card:focus-within', declarations: [{ property: 'outline', value: '2px solid blue' }] },
-      ] },
-      assets: [{ id: 'photo', source: sourceImage, status: 'ready', destination: 'assets/photo.png',
-        sha256: createHash('sha256').update(image).digest('hex') },
-      { id: 'logo', source: sourceSvg, status: 'ready', destination: 'assets/logo.svg',
-        sha256: createHash('sha256').update(svg).digest('hex'), uses: [{ node: 'logo', attribute: 'url' }] },
-      { id: 'body-font', source: sourceFont, kind: 'font', status: 'ready', destination: 'assets/body.woff2',
-        sha256: createHash('sha256').update(font).digest('hex'),
-        fontLicense: { ownership: 'IBM Corp.', license: 'OFL-1.1', notice: fontNotice } }], files: [], warnings: [],
-    });
-    const plan = await planStandalonePluginOutput(output, { name: 'acme/notice',
-      files: Object.fromEntries([...generated.files, ...generated.assets].map((file) => [file.path, file.content])) });
-
-    await writePluginOutput(plan);
-    const lock = JSON.parse(await readFile(path.join(output, 'package-lock.json'), 'utf8')) as {
-      packages: Record<string, { version?: string }>;
-    };
-    expect(lock.packages['node_modules/@wordpress/scripts']?.version).toBe('34.2.0');
-    await expect(stat(path.join(output, 'node_modules'))).rejects.toThrow();
-
-    const npmEnvironment = await npmEnvironmentForGeneratedPlugin(output);
-    await execFileAsync('npm', ['ci', '--include=dev', '--no-audit', '--no-fund'], {
-      cwd: output,
-      timeout: 120_000,
-      env: npmEnvironment,
-    });
-    await execFileAsync('npm', ['run', 'zip'], { cwd: output, timeout: 120_000,
-      env: { ...npmEnvironment, NODE_ENV: 'production' } });
-    const archive = path.join(output, 'acme-notice.zip');
-    expect(await stat(archive)).toBeTruthy();
-    await execFileAsync('npm', ['run', 'test:zip', '--', archive], { cwd: output, timeout: 30_000 });
-
-    const { stdout } = await execFileAsync('unzip', ['-Z1', archive]);
-    const entries = stdout.split(/\r?\n/).filter(Boolean);
-    expect(() => assertStandaloneZipEntries(entries, 'notice', ['index.js', 'style-index.css', 'index.css'])).not.toThrow();
-    const archiveBytes = async (entry: string): Promise<Buffer> =>
-      (await execFileAsync('unzip', ['-p', archive, entry], { encoding: 'buffer', timeout: 10_000 })).stdout;
-    const sharedCssPath = entries.find((entry) => entry.endsWith('/blocks/notice/style-index.css'))!;
-    const editorCssPath = entries.find((entry) => entry.endsWith('/blocks/notice/index.css'))!;
-    const css = (await archiveBytes(sharedCssPath)).toString('utf8');
-    expect(css).toContain(':where(.wp-block-acme-notice) .card');
-    expect(css).toMatch(/@media\s*\(min-width:\s*48rem\)/);
-    expect(css).toContain('translateY(-2px)');
-    expect(css).not.toContain('./assets/photo.png');
-    expect(css).not.toContain('focus-within');
-    expect(css).toContain('@font-face');
-    expect(css).toContain(fontFamily);
-    expect(css).not.toContain(sourceFont);
-    const noticePath = entries.find((entry) => entry.endsWith('/blocks/notice/font-licenses.txt'));
-    expect(noticePath).toBeDefined();
-    const notice = (await archiveBytes(noticePath!)).toString('utf8');
-    expect(notice).toContain('Copyright © 2017 IBM Corp.');
-    expect(notice).toContain('SIL OPEN FONT LICENSE Version 1.1');
-    expect(notice).toContain('OTHER DEALINGS IN THE FONT SOFTWARE.');
-    expect(notice).not.toContain(sourceFont);
-    const fonts = entries.filter((entry) => /\/build\/.*\.woff2$/.test(entry));
-    expect(fonts).toHaveLength(1);
-    expect(await archiveBytes(fonts[0]!)).toEqual(font);
-    expect(css).toContain(path.basename(fonts[0]!));
-    expect((await archiveBytes(editorCssPath)).toString('utf8')).not.toContain('@font-face');
-    expect((await archiveBytes(editorCssPath)).toString('utf8')).toContain('.card:focus-within');
-    const images = entries.filter((entry) => /\/build\/images\/.*\.png$/.test(entry));
-    expect(images).toHaveLength(1);
-    expect(await archiveBytes(images[0]!)).toEqual(image);
-    expect(css).toContain(path.basename(images[0]!));
-    expect(entries.some((entry) => entry.endsWith('.map'))).toBe(false);
-    // CSS SVGs can be inline. Native Image URLs must be emitted files because WordPress strips
-    // data: URLs from filtered post content, even when the source SVG itself is safe.
-    const svgData = /data:image\/svg\+xml(?:;charset=[^;,]+)?(?:;base64)?,[^)"'\s]+/.exec(css)?.[0];
-    expect(svgData).toBeDefined();
-    const [header, payload] = svgData!.split(',', 2);
-    const cssSvg = header!.includes(';base64') ? Buffer.from(payload!, 'base64') : Buffer.from(decodeURIComponent(payload!));
-    expect(cssSvg.toString()).toContain('viewBox="0 0 80 40"');
-    expect(cssSvg.toString()).toContain('#123456');
-    const scriptPath = entries.find((entry) => entry.endsWith('/blocks/notice/index.js'))!;
-    const script = (await archiveBytes(scriptPath)).toString('utf8');
-    const svgFiles = entries.filter((entry) => /\/build\/.*\.svg$/.test(entry));
-    expect(svgFiles).toHaveLength(1);
-    expect(await archiveBytes(svgFiles[0]!)).toEqual(svg);
-    expect(script).toContain(path.basename(svgFiles[0]!));
-    expect(script).not.toContain('data:image/svg+xml');
-    expect(script).not.toContain('./assets/logo.svg');
-
-    // Reuse this real installed wp-scripts host to exercise the other delivery profile.
-    // Adding a second block must retain the first block's source and produce both build leaves.
-    const existingSource = new Map(await Promise.all([...generated.files, ...generated.assets].map(async (file) => [
-      file.path, await readFile(path.join(output, 'src/blocks/notice', file.path)),
-    ] as const)));
-    const addition = compileRegisteredBlock({
-      version: 1, generatorVersion: '0.9.0', target: { name: 'acme/second-notice', title: 'Second notice' },
-      structure: [{ id: 'message', block: 'core/paragraph', attributes: { content: 'An independently registered second block.' } }],
-      fields: [{ id: 'message', node: 'message', attribute: 'content', label: 'Message', mode: 'editable' }],
-      locking: { mode: 'contentOnly' }, styles: { strategy: 'native', outcomes: [] },
-      pattern: { ready: false, overrides: [] }, assets: [], files: [], warnings: [],
-    });
-    const integration = await planExistingPluginOutput(output, { name: 'acme/second-notice',
-      files: Object.fromEntries(addition.files.map((file) => [file.path, file.content])) });
-    expect(integration.mode).toBe('existing');
-    await writePluginOutput(integration, { authorizedReplacements: integration.touchedFiles
-      .filter((file) => file.operation === 'modify').map((file) => file.path) });
-    for (const [relative, bytes] of existingSource) {
-      expect(await readFile(path.join(output, 'src/blocks/notice', relative))).toEqual(bytes);
-    }
-    await execFileAsync('npm', ['run', 'zip'], { cwd: output, timeout: 120_000,
-      env: { ...npmEnvironment, NODE_ENV: 'production' } });
-    await execFileAsync('npm', ['run', 'test:zip', '--', archive], { cwd: output, timeout: 30_000 });
-    const rebuiltEntries = (await execFileAsync('unzip', ['-Z1', archive])).stdout.split(/\r?\n/).filter(Boolean);
-    for (const leaf of ['notice', 'second-notice']) {
-      const metadataEntry = rebuiltEntries.find((entry) => entry.endsWith(`/build/blocks/${leaf}/block.json`));
-      expect(metadataEntry).toBeDefined();
-      expect(JSON.parse((await archiveBytes(metadataEntry!)).toString('utf8')).name).toBe(`acme/${leaf}`);
-    }
-    const manifest = await readFile(path.join(output, 'build/blocks-manifest.php'), 'utf8');
-    expect(manifest).toContain("'notice'");
-    expect(manifest).toContain("'second-notice'");
-  }, 300_000);
 });
 
 async function existingDirectPlugin(): Promise<string> {

--- a/dev/test/release-activation-contract.test.ts
+++ b/dev/test/release-activation-contract.test.ts
@@ -33,6 +33,13 @@ describe('release command capture', () => {
   });
 });
 
+describe('release consumer archive coverage', () => {
+  it('runs the consumer archive suite in the full matrix and treats a failed row as failed release status', () => {
+    expect(source).toContain("runRow('candidate-consumer-tests', 'npm', ['run', 'test:consumer']);");
+    expect(source).toContain("statuses.includes('failed') ? 'failed'");
+  });
+});
+
 describe('release evidence paths', () => {
   it('keeps receipt artifacts beside an extensionless receipt stem', () => {
     const begin = source.indexOf('function artifactDirectoryForReceipt(');

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "tune": "tsx scripts/tune.ts",
     "tune:t0": "tsx scripts/tune.ts --tier t0",
     "test": "vitest run",
+    "test:consumer": "vitest run --config vitest.consumer.config.ts",
     "test:proof": "vitest run dev/test/proof.test.ts dev/test/proof-pattern-overrides.test.ts",
     "test:proof:wordpress": "vitest run --config vitest.wordpress.config.ts",
     "test:proof:mutations": "BLOCK_RUNNER_PROOF_MUTATIONS=1 vitest run dev/test/proof-mutations.integration.test.ts",

--- a/scripts/release-check.mjs
+++ b/scripts/release-check.mjs
@@ -43,6 +43,7 @@ mkdirSync(evidenceDirectory, { recursive: true });
 try {
   if (selected === 'full-release-matrix') {
     runRow('candidate-verify', 'npm', ['run', 'verify']);
+    runRow('candidate-consumer-tests', 'npm', ['run', 'test:consumer']);
     const plans = valueFor('--plans');
     if (plans) {
       const authoring = runRow('authoring-wordpress-71-proof', 'npm', ['run', 'authoring:prove', '--', '--plans', path.resolve(plans)]);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,12 @@ export default defineConfig({
     include: ['dev/test/**/*.test.ts'],
     // The Docker/wp-env lifecycle is a separately invoked acceptance command.
     // `npm test` stays a fast repository check even on machines without Docker.
-    exclude: ['dev/test/proof-real-wordpress.test.ts', 'dev/test/proof-query-wordpress.test.ts'],
+    exclude: [
+      'dev/test/proof-real-wordpress.test.ts',
+      'dev/test/proof-query-wordpress.test.ts',
+      'dev/test/plugin.consumer.test.ts',
+      'dev/test/proof-native-style-adapter-builder.test.ts',
+    ],
     // Each file boots a full headless Gutenberg runtime. Parallel boots contend heavily enough
     // to cross the timeout together on developer machines, so serialize files for a stable gate.
     fileParallelism: false,

--- a/vitest.consumer.config.ts
+++ b/vitest.consumer.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: [
+      'dev/test/plugin.consumer.test.ts',
+      'dev/test/proof-native-style-adapter-builder.test.ts',
+    ],
+    fileParallelism: false,
+    testTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Problem

The default repository suite performed two clean consumer/archive builds on every Node version. Those checks are valuable, but they are a separate environment and cost boundary from the deterministic repository tests. Closes #92.

## Solution

The two archive builders now run once in a serial `test:consumer` suite. The default suite excludes only those files; CI’s package-boundary job and the full release matrix explicitly run the consumer suite so its assertions remain release-blocking.

## Diff

`+114 −153 · 9 files · no assertions removed`

```text
npm test              -> deterministic repository suite
npm run test:consumer -> standalone release archive + native adapter archive
CI/release            -> both routes
```

## Testing & verification

Reviewed revision: `768ecf4` · local Node `v22.23.1` · npm `10.9.8`

- `npm run test:consumer` — 2 files / 2 tests passed in 31.93s.
- `npm run typecheck` — passed in 2.876s.
- `node --import tsx scripts/authoring-hashes.ts --check` — passed in 0.260s.
- Discovery confirmed the default suite contains neither moved archive test and the consumer config contains exactly both moved files.
- `git diff --check` — passed.

The CI matrix is the compatibility gate for this split. A clean local Node 22.23 install hit an unrelated existing `wesper@0.0.3` → `zod/v4` ESM-resolution failure in `styles.test.ts`; it is outside this PR’s files and is not presented as a passing default-suite result.

## Risk / rollout

The moved archive checks retain their original 300-second per-test allowance and serial execution. CI and the full release matrix fail if the consumer route fails; reverting this commit restores the former default-suite placement.
