### PR TITLE
Benchmark: isolate page-intent skill input

### DIFF
--- a/dev/benchmarks/README.md
+++ b/dev/benchmarks/README.md
@@ -126,10 +126,10 @@ deterministic **rules engine** in `src/` (no `--engine` flag): it walks authored
 through its rule set and assembles native blocks — cheap, valid, and unbeatable on clean
 semantic input, but it falls back to `core/html` on markup it doesn't recognize.
 
-The other real engine is **Engine C** — a *split* engine in `scripts/engines/engine-c.ts`
+The other real engine is **Engine Skill** — a *split* engine in `scripts/engines/engine-skill.ts`
 (+ its deterministic core `intent.ts`). It separates the two halves of conversion:
 
-- **propose** (`engine-c.ts`) — the costly, non-deterministic half: the model reads the HTML
+- **propose** (`engine-skill.ts`) — the costly, non-deterministic half: the model reads the HTML
   and emits a typed block-**intent** tree (block names + nesting + which content goes where),
   *never* markup.
 - **realize** (`intent.ts`) — the deterministic half: `assemble()` turns that intent into a
@@ -138,26 +138,31 @@ The other real engine is **Engine C** — a *split* engine in `scripts/engines/e
   is a backstop, not a halving tax. Every failure is bounded to wrong structure/attributes,
   never invalid markup.
 
-Engine C exports the tuner's split contract — `propose` / `realize` / `promptHash` — so the
+Engine Skill exports the tuner's split contract — `propose` / `realize` / `promptHash` — so the
 tuner caches the model's intent tree once and replays `realize()` for free (T0) while you
 iterate on the assembler, calling the model again only when the prompt or schema changes.
+
+Engine Skill reads the page-intent pair in this exact order: `GUIDE.md` (17,949 UTF-8 bytes),
+then `ASSEMBLE.md` (9,617 UTF-8 bytes), for 27,566 source bytes at this revision. The ordinary
+`block-runner skill` command still prints the complete reference bundle. These are source-byte
+counts only; no model-quality, latency, or score change is asserted.
 
 All CLI-backed benchmark engines receive their complete task through stdin and launch outside
 the repository. Codex runs with a read-only sandbox, ignored user configuration, and ephemeral
 sessions; Claude runs in safe, restricted, non-persistent mode. A prompt asking the model not
 to write files is not a security boundary, so bypass-permission modes are prohibited here.
 
-Run Engine C:
+Run Engine Skill:
 
 ```sh
-npm run tune  -- --tier t2 --engine scripts/engines/engine-c.ts --engine-label engine-c --model opus
-npm run tune  -- --tier t2 --engine scripts/engines/engine-c.ts --engine-label engine-c --model gpt-5.5 --cli codex --effort high
-npm run bench -- --engine scripts/engines/engine-c.ts --engine-label engine-c --model opus --record
+npm run tune  -- --tier t2 --engine scripts/engines/engine-skill.ts --engine-label engine-skill --model opus
+npm run tune  -- --tier t2 --engine scripts/engines/engine-skill.ts --engine-label engine-skill --model gpt-5.5 --cli codex --effort high
+npm run bench -- --engine scripts/engines/engine-skill.ts --engine-label engine-skill --model opus --record
 ```
 
 - `--engine <path>` (or `BLOCK_RUNNER_ENGINE`) — the engine module; omit for the local rules.
 - `--engine-label` / `--model` / `--effort` — recorded as the run's `engine` / `model` / `effort` provenance.
-- `--cli claude` (default; harness/OAuth, no API key) or `--cli codex` — which model CLI Engine C shells out to.
+- `--cli claude` (default; harness/OAuth, no API key) or `--cli codex` — which model CLI Engine Skill shells out to.
 - `--producer <name>` / `--layouts a,b` — scope a run to a subset (cheap iteration; don't `--record` a scoped run as a baseline).
 
 To add an engine: drop a module in `scripts/engines/`. Prefer the **split-engine contract** —

--- a/dev/test/benchmark.test.ts
+++ b/dev/test/benchmark.test.ts
@@ -7,7 +7,7 @@ import { realize } from '../../src/index.js';
 import { INTENT_PROMPT } from '../../scripts/engines/intent.js';
 import { CONVERT_PROMPT } from '../../scripts/engines/prompt.js';
 import { claudePrintArgs, codexExecArgs, MODEL_WORKDIR } from '../../scripts/engines/harness.js';
-import { readCanonicalSkillGuide } from '../../src/skill.js';
+import { readPageIntentSkillGuideSync } from '../../src/skill.js';
 import {
   WORDPRESS_TARGET,
   expectedToDisplay,
@@ -169,7 +169,7 @@ describe('benchmark contract', () => {
   it('keeps every expected block registered and present in every model-facing contract', async () => {
     const specs = loadSpecs();
     const wp = await getWp();
-    const guide = await readCanonicalSkillGuide();
+    const guide = readPageIntentSkillGuideSync();
     const blocks = new Set<string>();
     for (const spec of specs.values()) {
       for (const tree of allTrees(spec)) walk(tree, (node) => blocks.add(node.block));
@@ -179,7 +179,7 @@ describe('benchmark contract', () => {
       expect(wp.getBlockType(block), `${block} must be registered`).toBeTruthy();
       expect(CONVERT_PROMPT, `${block} missing from direct prompt`).toContain(block);
       expect(INTENT_PROMPT, `${block} missing from intent prompt`).toContain(block);
-      expect(guide, `${block} missing from shipped guide`).toContain(block);
+      expect(guide, `${block} missing from page-intent engine guide`).toContain(block);
     }
   });
 

--- a/dev/test/engine-skill.test.ts
+++ b/dev/test/engine-skill.test.ts
@@ -1,0 +1,119 @@
+import { createHash } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cacheKey } from '../../scripts/tuner/cache.js';
+
+const TASK = `
+---
+
+Your task: convert the HTML below into an intent tree, following the guide above.
+
+Output ONLY the intent JSON, between a line ===INTENT_START=== and a line ===INTENT_END===.
+Do not run any commands, write any files, or output block markup.
+
+HTML:
+`;
+
+function pageGuide(guide: string, assemble: string): string {
+  return `${guide.endsWith('\n') ? guide : `${guide}\n`}\n---\n\n<!-- references/ASSEMBLE.md -->\n\n${assemble.endsWith('\n') ? assemble : `${assemble}\n`}`;
+}
+
+interface SourceReferences {
+  guide: string;
+  assemble: string | Error;
+  authoring: string;
+}
+
+async function loadEngine(references: SourceReferences) {
+  const execFileSync = vi.fn((_command: string, _args: string[], _options: { input?: string }) => '{"blocks":[]}');
+  const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+  vi.resetModules();
+  vi.doMock('node:child_process', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('node:child_process')>()),
+    execFileSync,
+  }));
+  vi.doMock('node:fs', () => ({
+    ...actualFs,
+    readFileSync(file: string, encoding: string) {
+      const name = file.split('/').at(-1);
+      const source = name === 'GUIDE.md'
+        ? references.guide
+        : name === 'ASSEMBLE.md'
+          ? references.assemble
+          : name === 'AUTHORING.md'
+            ? references.authoring
+            : undefined;
+      if (source instanceof Error) throw source;
+      if (source !== undefined) return source;
+      return actualFs.readFileSync(file, encoding as BufferEncoding);
+    },
+  }));
+  const engine = await import('../../scripts/engines/engine-skill.js');
+  return { engine, execFileSync };
+}
+
+afterEach(() => {
+  vi.doUnmock('node:child_process');
+  vi.doUnmock('node:fs');
+  vi.resetModules();
+});
+
+function identity(promptHash: string, instructionProvenance: { guideHash: string }): string {
+  return cacheKey({
+    engineLabel: 'engine-skill',
+    model: 'test-model',
+    effort: 'low',
+    inputHtml: '<p>same input</p>',
+    promptHash,
+    instructionProvenance,
+  });
+}
+
+describe('skill benchmark engine', () => {
+  it('passes the selected page references, task framing, and HTML to a mocked subprocess', async () => {
+    const references = { guide: 'GUIDE α', assemble: 'ASSEMBLE β\n', authoring: 'AUTHORING excluded' };
+    const { engine, execFileSync } = await loadEngine(references);
+    const selected = pageGuide(references.guide, references.assemble);
+
+    await engine.propose('<main>input</main>');
+
+    expect(execFileSync).toHaveBeenCalledOnce();
+    expect(execFileSync.mock.calls[0]?.[2]).toMatchObject({ input: `${selected}${TASK}<main>input</main>` });
+  });
+
+  it('changes page identity for selected references but not an excluded authoring reference', async () => {
+    const baseReferences = { guide: 'GUIDE', assemble: 'ASSEMBLE', authoring: 'AUTHORING original' };
+    const authoringOnlyChange = { ...baseReferences, authoring: 'AUTHORING changed' };
+    const selectedChange = { ...baseReferences, guide: 'GUIDE changed' };
+    const baseRun = await loadEngine(baseReferences);
+    await baseRun.engine.propose('<p>same input</p>');
+    const base = baseRun.engine;
+    const basePromptHash = base.promptHash;
+    const baseProvenance = base.agentSkillProvenance;
+    const authoringRun = await loadEngine(authoringOnlyChange);
+    await authoringRun.engine.propose('<p>same input</p>');
+    const authoring = authoringRun.engine;
+    const changedRun = await loadEngine(selectedChange);
+    await changedRun.engine.propose('<p>same input</p>');
+    const changed = changedRun.engine;
+    const changedPromptHash = changed.promptHash;
+    const changedProvenance = changed.agentSkillProvenance;
+
+    expect(baseRun.execFileSync.mock.calls[0]?.[2]).toMatchObject({ input: expect.not.stringContaining('AUTHORING original') });
+    expect(authoringRun.execFileSync.mock.calls[0]?.[2]).toMatchObject({ input: expect.not.stringContaining('AUTHORING changed') });
+    expect(authoringRun.execFileSync.mock.calls[0]?.[2]).toMatchObject({ input: baseRun.execFileSync.mock.calls[0]?.[2]?.input });
+    expect(basePromptHash).not.toBe(changedPromptHash);
+    expect(baseProvenance).not.toEqual(changedProvenance);
+    expect(identity(basePromptHash, baseProvenance)).not.toBe(identity(changedPromptHash, changedProvenance));
+    expect(authoring.promptHash).toBe(basePromptHash);
+    expect(authoring.agentSkillProvenance).toEqual(baseProvenance);
+    expect(identity(authoring.promptHash, authoring.agentSkillProvenance)).toBe(identity(basePromptHash, baseProvenance));
+  });
+
+  it('hashes the exact selected reference text', async () => {
+    const source = { guide: 'GUIDE', assemble: 'ASSEMBLE', authoring: 'AUTHORING excluded' };
+    const { engine } = await loadEngine(source);
+    const expected = `sha256:${createHash('sha256').update(pageGuide(source.guide, source.assemble)).digest('hex')}`;
+
+    expect(engine.agentSkillProvenance).toEqual({ guideHash: expected });
+  });
+});

--- a/dev/test/skill.test.ts
+++ b/dev/test/skill.test.ts
@@ -1,8 +1,13 @@
 import { readFile } from 'node:fs/promises';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readCanonicalSkillGuide, validateCanonicalSkill } from '../../src/skill.js';
 import { validateAuthoringPlan } from '../../src/authoring/schema.js';
 import { compileRegisteredBlock } from '../../src/authoring/generate.js';
+
+afterEach(() => {
+  vi.doUnmock('node:fs');
+  vi.resetModules();
+});
 
 describe('canonical agent skill', () => {
   it('compiles the complete registered-block plan taught to calling agents', async () => {
@@ -76,5 +81,42 @@ describe('canonical agent skill', () => {
     for (const reference of fixture.routes.flatMap((entry) => (entry.firstReference ? [entry.firstReference] : []))) {
       expect(skill).toContain(reference.split('#', 1)[0]!);
     }
+  });
+
+  it('reads only the ordered page references with Unicode and trailing-newline normalization', async () => {
+    const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const reads: string[] = [];
+    vi.resetModules();
+    vi.doMock('node:fs', () => ({
+      ...actual,
+      readFileSync(file: string, encoding: string) {
+        reads.push(file);
+        if (file.endsWith('/GUIDE.md')) return 'guide α';
+        if (file.endsWith('/ASSEMBLE.md')) return 'assemble β\n';
+        throw new Error(`unexpected page reference read: ${file}`);
+      },
+    }));
+    const { readPageIntentSkillGuideSync } = await import('../../src/skill.js');
+
+    expect(readPageIntentSkillGuideSync()).toBe(
+      'guide α\n\n---\n\n<!-- references/ASSEMBLE.md -->\n\nassemble β\n',
+    );
+    expect(reads.map((file) => file.split('/').at(-1))).toEqual(['GUIDE.md', 'ASSEMBLE.md']);
+  });
+
+  it('surfaces a missing selected page reference', async () => {
+    const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+    vi.resetModules();
+    vi.doMock('node:fs', () => ({
+      ...actual,
+      readFileSync(file: string, encoding: string) {
+        if (file.endsWith('/GUIDE.md')) return 'guide\n';
+        if (file.endsWith('/ASSEMBLE.md')) throw new Error('ENOENT: no such file or directory');
+        return actual.readFileSync(file, encoding as BufferEncoding);
+      },
+    }));
+    const { readPageIntentSkillGuideSync } = await import('../../src/skill.js');
+
+    expect(() => readPageIntentSkillGuideSync()).toThrow('ENOENT: no such file or directory');
   });
 });

--- a/scripts/engines/engine-skill.ts
+++ b/scripts/engines/engine-skill.ts
@@ -13,51 +13,26 @@
  *     --producer claude-impeccable --layouts hero-cover,pricing-table
  */
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import type { ConvertOptions, BlockRunnerReport } from '../../src/types.js';
-import { readCanonicalSkillGuideSync } from '../../src/skill.js';
+import { readPageIntentSkillGuideSync } from '../../src/skill.js';
 import { realize } from './intent.js';
 import { claudePrintArgs, codexExecArgs, MODEL_WORKDIR } from './harness.js';
 
-const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
-const GUIDE = readCanonicalSkillGuideSync();
+const PAGE_GUIDE = readPageIntentSkillGuideSync();
 
 export interface AgentSkillProvenance {
   guideHash: string;
-  authoringCommandHash: string;
-  authoringSchemaHash: string;
 }
 
 function hash(value: string): string {
   return `sha256:${createHash('sha256').update(value).digest('hex')}`;
 }
 
-/** Hash the implemented command and plan contract which the guide directs models to use. */
-function hashSourceSet(paths: string[]): string {
-  return hash(paths.map((relativePath) => {
-    const sourcePath = path.join(ROOT, relativePath);
-    if (!existsSync(sourcePath)) {
-      throw new Error(`authoring provenance source is missing: ${relativePath}`);
-    }
-    const content = readFileSync(sourcePath, 'utf8');
-    return `${relativePath}\0${content}`;
-  }).join('\0'));
-}
-
-// The guide tells the model which authoring command and schema it must use. Record all three
-// components individually as well as in promptHash: the aggregate invalidates the tuner cache;
-// named values make a historical benchmark run independently auditable.
+// This engine only reads the page-intent references. The hash records that exact ordered text so
+// cache records remain independently auditable without coupling to registered-block authoring.
 export const agentSkillProvenance: AgentSkillProvenance = Object.freeze({
-  guideHash: hash(GUIDE),
-  authoringCommandHash: hashSourceSet(['src/cli.ts']),
-  authoringSchemaHash: hashSourceSet([
-    'src/authoring/schema.ts',
-    'src/authoring/preview.ts',
-    'src/authoring/destination.ts',
-  ]),
+  guideHash: hash(PAGE_GUIDE),
 });
 
 // The framing an agent supplies around the guide when it has been handed a design to convert.
@@ -73,11 +48,9 @@ Do not run any commands, write any files, or output block markup.
 HTML:
 `;
 
-// The shipped guide is itself an engine prompt. Include the authoring command/schema revisions:
-// a guide sentence that names an old plan shape or write workflow is not reproducible against a
-// newer deterministic implementation. Tuner cache keys and benchmark records use this value.
+// Tuner cache keys and benchmark records use the actual page prompt, not unrelated references.
 export const promptHash = `skill-${createHash('sha256')
-  .update(GUIDE)
+  .update(PAGE_GUIDE)
   .update(TASK)
   .update(JSON.stringify(agentSkillProvenance))
   .digest('hex')
@@ -121,7 +94,7 @@ function callModel(input: string): string {
 
 export async function propose(html: string, _opts?: ConvertOptions): Promise<{ raw: string; error?: string }> {
   try {
-    return { raw: callModel(GUIDE + TASK + html) };
+    return { raw: callModel(PAGE_GUIDE + TASK + html) };
   } catch (error) {
     return { raw: '', error: error instanceof Error ? error.message : String(error) };
   }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -52,6 +52,23 @@ interface InstallPlan {
 const SKILL_NAME = 'block-runner';
 const MANIFEST_NAME = '.block-runner-install.json';
 const SOURCE_DIRECTORY = fileURLToPath(new URL('../skills/block-runner/', import.meta.url));
+const PAGE_INTENT_REFERENCE_NAMES = ['GUIDE.md', 'ASSEMBLE.md'] as const;
+
+function readSkillReferencesSync(names: readonly string[]): string {
+  const referencesDirectory = path.join(SOURCE_DIRECTORY, 'references');
+  const readWithTrailingNewline = (name: string): string => {
+    const fileContent = readFileSync(path.join(referencesDirectory, name), 'utf8');
+    return fileContent.endsWith('\n') ? fileContent : `${fileContent}\n`;
+  };
+
+  return names
+    .map((name, index) =>
+      index === 0
+        ? readWithTrailingNewline(name)
+        : `\n---\n\n<!-- references/${name} -->\n\n${readWithTrailingNewline(name)}`,
+    )
+    .join('');
+}
 
 // `npx block-runner skill` prints the whole reference set so a harness without skill support
 // gets the same information as the installed skill.
@@ -68,18 +85,13 @@ export function readCanonicalSkillGuideSync(): string {
   names.splice(guideIndex, 1);
   names.unshift('GUIDE.md');
 
-  const readWithTrailingNewline = (name: string): string => {
-    const fileContent = readFileSync(path.join(referencesDirectory, name), 'utf8');
-    return fileContent.endsWith('\n') ? fileContent : `${fileContent}\n`;
-  };
+  return readSkillReferencesSync(names);
+}
 
-  return names
-    .map((name, index) =>
-      index === 0
-        ? readWithTrailingNewline(name)
-        : `\n---\n\n<!-- references/${name} -->\n\n${readWithTrailingNewline(name)}`,
-    )
-    .join('');
+// Benchmark page-intent conversion needs the shared guide plus the complete intent schema.
+// Keep the CLI's full-bundle reader above unchanged; this is deliberately not a configurable API.
+export function readPageIntentSkillGuideSync(): string {
+  return readSkillReferencesSync(PAGE_INTENT_REFERENCE_NAMES);
 }
 
 export async function readCanonicalSkillGuide(): Promise<string> {


### PR DESCRIPTION
## Problem

The page-intent benchmark engine loaded the whole skill bundle and tied its cache identity to registered-block authoring sources it never uses. Closes #90.

## Solution

The page engine now reads only `GUIDE.md` then `ASSEMBLE.md`, and hashes that exact ordered text in its prompt identity and provenance. The public `block-runner skill` command still reads the complete bundle.

## Diff

`+180 −58 · 6 files · no public API or model call change`

```text
page engine: GUIDE.md + ASSEMBLE.md -> prompt + provenance + cache key
CLI skill:   complete bundle        -> unchanged
```

## Testing & verification

Reviewed revision: `43f0922`

- `npm run typecheck` — passed.
- `npx --no-install vitest run dev/test/benchmark.test.ts dev/test/skill.test.ts dev/test/engine-skill.test.ts` — passed.
- `npx --no-install vitest run dev/test/cli.test.ts -t 'prints the agent guide with skill'` — passed.
- `git diff --check` — passed.

Mocked filesystem/subprocess tests cover exact ordering, Unicode, missing selected input, newline normalisation, and selected versus excluded reference changes. The selected prompt is 27,566 UTF-8 source bytes at this revision; no model-quality, latency, or score claim was measured.

## Risk / rollout

Historical records are untouched. The changed identity prevents reuse of the old full-bundle cache; reverting this commit restores the former prompt coupling.
