### PR TITLE
CI: select conservative checks by pull request scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,121 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('ci-pr-{0}', github.event.pull_request.number) || format('ci-run-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  classify:
+    runs-on: ubuntu-latest
+    outputs:
+      route: ${{ steps.scope.outputs.route }}
+      docs: ${{ steps.scope.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: scope
+        name: Classify changed paths
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo 'route=full' >> "$GITHUB_OUTPUT"
+            echo 'docs=[]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          result="$(node scripts/ci-scope.mjs --base '${{ github.event.pull_request.base.sha }}' --head '${{ github.event.pull_request.head.sha }}')"
+          echo "$result"
+          route="$(node --input-type=module --eval "console.log(JSON.parse(process.argv[1]).route)" "$result")"
+          docs="$(node --input-type=module --eval "console.log(JSON.stringify(JSON.parse(process.argv[1]).docs))" "$result")"
+          echo "route=$route" >> "$GITHUB_OUTPUT"
+          echo "docs=$docs" >> "$GITHUB_OUTPUT"
+
+  documentation-contracts:
+    needs: classify
+    if: needs.classify.outputs.route == 'docs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.13.0
+          cache: npm
+      - run: npm install -g npm@11
+      - run: npm ci --engine-strict
+      - name: Verify documentation contracts
+        run: npx --no-install vitest run dev/test/skill.test.ts dev/test/node-support.test.ts
+      - run: npm run check:private
+      - name: Check touched documentation whitespace and local links
+        env:
+          DOCS: ${{ needs.classify.outputs.docs }}
+        run: |
+          git diff --check '${{ github.event.pull_request.base.sha }}' '${{ github.event.pull_request.head.sha }}'
+          node --input-type=module <<'NODE'
+          import { existsSync, readFileSync } from 'node:fs';
+          import path from 'node:path';
+
+          const docs = JSON.parse(process.env.DOCS ?? '[]');
+          for (const document of docs) {
+            if (!existsSync(document)) continue;
+            const text = readFileSync(document, 'utf8');
+            for (const match of text.matchAll(/!?\[[^\]]*\]\(([^)\s]+)(?:\s+[^)]*)?\)/g)) {
+              const reference = match[1];
+              if (/^(?:[a-z][a-z+.-]*:|#|\/)/i.test(reference)) continue;
+              const target = reference.split('#', 1)[0];
+              if (target && !existsSync(path.resolve(path.dirname(document), target))) {
+                throw new Error(`${document}: missing local Markdown link target ${reference}`);
+              }
+            }
+          }
+          NODE
+
+  skill-contracts:
+    needs: classify
+    if: needs.classify.outputs.route == 'skill'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.13.0
+          cache: npm
+      - run: npm install -g npm@11
+      - run: npm ci --engine-strict
+      - name: Verify documentation and skill CLI contracts
+        run: npx --no-install vitest run dev/test/skill.test.ts dev/test/node-support.test.ts dev/test/cli.test.ts
+      - run: npm run check:private
+      - name: Check touched documentation whitespace and local links
+        env:
+          DOCS: ${{ needs.classify.outputs.docs }}
+        run: |
+          git diff --check '${{ github.event.pull_request.base.sha }}' '${{ github.event.pull_request.head.sha }}'
+          node --input-type=module <<'NODE'
+          import { existsSync, readFileSync } from 'node:fs';
+          import path from 'node:path';
+
+          const docs = JSON.parse(process.env.DOCS ?? '[]');
+          for (const document of docs) {
+            if (!existsSync(document)) continue;
+            const text = readFileSync(document, 'utf8');
+            for (const match of text.matchAll(/!?\[[^\]]*\]\(([^)\s]+)(?:\s+[^)]*)?\)/g)) {
+              const reference = match[1];
+              if (/^(?:[a-z][a-z+.-]*:|#|\/)/i.test(reference)) continue;
+              const target = reference.split('#', 1)[0];
+              if (target && !existsSync(path.resolve(path.dirname(document), target))) {
+                throw new Error(`${document}: missing local Markdown link target ${reference}`);
+              }
+            }
+          }
+          NODE
+      - name: Verify the packed skill consumer
+        run: |
+          test -f dist/cli.js
+          npm run smoke:package
+
   test:
+    needs: classify
+    if: needs.classify.outputs.route == 'full'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -35,6 +148,8 @@ jobs:
         run: npm run smoke:package:unsupported-node
 
   package-boundary:
+    needs: classify
+    if: needs.classify.outputs.route == 'full'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,6 +166,8 @@ jobs:
         run: npm run test:consumer
 
   wordpress-proof:
+    needs: classify
+    if: needs.classify.outputs.route == 'full'
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -93,3 +210,55 @@ jobs:
             !${{ runner.temp }}/block-runner-wordpress-7.1-receipt/**/node_modules/**
           if-no-files-found: warn
           retention-days: 14
+
+  ci-scope:
+    name: CI scope
+    if: always()
+    needs: [classify, documentation-contracts, skill-contracts, test, package-boundary, wordpress-proof]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the selected route and accept only intentional skips
+        env:
+          CLASSIFY: ${{ needs.classify.result }}
+          ROUTE: ${{ needs.classify.outputs.route }}
+          DOCS: ${{ needs.documentation-contracts.result }}
+          SKILL: ${{ needs.skill-contracts.result }}
+          TEST: ${{ needs.test.result }}
+          PACKAGE_BOUNDARY: ${{ needs.package-boundary.result }}
+          WORDPRESS_PROOF: ${{ needs.wordpress-proof.result }}
+        run: |
+          set -euo pipefail
+          if [ "$CLASSIFY" != success ]; then
+            echo "Path classifier did not succeed: $CLASSIFY"
+            exit 1
+          fi
+          case "$ROUTE" in
+            docs)
+              selected="$DOCS"
+              skipped="$SKILL $TEST $PACKAGE_BOUNDARY $WORDPRESS_PROOF"
+              ;;
+            skill)
+              selected="$SKILL"
+              skipped="$DOCS $TEST $PACKAGE_BOUNDARY $WORDPRESS_PROOF"
+              ;;
+            full)
+              selected="$TEST $PACKAGE_BOUNDARY $WORDPRESS_PROOF"
+              skipped="$DOCS $SKILL"
+              ;;
+            *)
+              echo "Classifier produced an invalid route: $ROUTE"
+              exit 1
+              ;;
+          esac
+          for result in $selected; do
+            if [ "$result" != success ]; then
+              echo "Selected CI job did not succeed: $result"
+              exit 1
+            fi
+          done
+          for result in $skipped; do
+            if [ "$result" != skipped ]; then
+              echo "Unselected CI job was not intentionally skipped: $result"
+              exit 1
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -516,7 +516,9 @@ npm run typecheck
 ```
 
 `npm run verify` remains the required repository gate. It runs the deterministic repository
-suite. Run `npm run test:consumer` separately to build the clean standalone release archive and
+suite. Pull requests that change only the root documentation allowlist or the shipped skill use
+their focused CI contracts; runtime, package, proof, workflow, release, unknown, and main-branch
+changes retain the full route. Run `npm run test:consumer` separately to build the clean standalone release archive and
 the native style-adapter fixture; it needs npm, `unzip`, and enough time for an isolated
 `npm ci` and two ZIP builds. Run `npm run build && npm run test:package`
 when changing exports, packed files, dependency pins, or consumer behavior. The full CI and

--- a/dev/test/ci-scope.test.mjs
+++ b/dev/test/ci-scope.test.mjs
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyChanges, classifyDiffResult, parseNameStatus } from '../../scripts/ci-scope.mjs';
+
+const entry = (status, ...paths) => ({ status, paths });
+
+test('selects the documentation route only for the root documentation allowlist', () => {
+  assert.deepEqual(
+    classifyChanges([entry('M', 'README.md'), entry('A', 'CHANGELOG.md')]),
+    { route: 'docs', docs: ['CHANGELOG.md', 'README.md'], reason: 'root-documentation-only' },
+  );
+});
+
+test('selects the skill route for skills with optional root documentation', () => {
+  assert.deepEqual(
+    classifyChanges([
+      entry('M', 'skills/block-runner/SKILL.md'),
+      entry('M', 'skills/block-runner/references/GUIDE.md'),
+      entry('M', 'README.md'),
+    ]),
+    {
+      route: 'skill',
+      docs: ['README.md', 'skills/block-runner/SKILL.md', 'skills/block-runner/references/GUIDE.md'],
+      reason: 'skill-and-root-documentation-only',
+    },
+  );
+});
+
+test('keeps mixed documentation and runtime changes on the full route', () => {
+  assert.equal(classifyChanges([entry('M', 'README.md'), entry('M', 'src/index.ts')]).route, 'full');
+});
+
+test('keeps unknown Markdown on the full route', () => {
+  assert.equal(classifyChanges([entry('M', 'dev/benchmarks/README.md')]).route, 'full');
+});
+
+test('uses both sides of a rename', () => {
+  assert.equal(classifyChanges([entry('R100', 'README.md', 'src/README.md')]).route, 'full');
+  assert.equal(classifyChanges([entry('R100', 'skills/block-runner/SKILL.md', 'README.md')]).route, 'skill');
+});
+
+test('uses deleted paths', () => {
+  assert.equal(classifyChanges([entry('D', 'scripts/old-check.mjs')]).route, 'full');
+  assert.equal(classifyChanges([entry('D', 'ERRORS.md')]).route, 'docs');
+});
+
+test('keeps empty input and unavailable or malformed diffs on the full route', () => {
+  assert.equal(classifyChanges([]).route, 'full');
+  assert.deepEqual(classifyDiffResult({ ok: false }), {
+    route: 'full', docs: [], reason: 'diff-unavailable', classifierFailed: true,
+  });
+  const malformed = classifyDiffResult({ ok: true, output: 'Q\tREADME.md\n' });
+  assert.equal(malformed.route, 'full');
+  assert.equal(malformed.classifierFailed, true);
+});
+
+test('parses git name-status output including renames and deletions', () => {
+  assert.deepEqual(parseNameStatus('R100\tREADME.md\tskills/block-runner/README.md\nD\tERRORS.md\n'), [
+    entry('R100', 'README.md', 'skills/block-runner/README.md'),
+    entry('D', 'ERRORS.md'),
+  ]);
+});

--- a/scripts/ci-scope.mjs
+++ b/scripts/ci-scope.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/** Classify a complete git name-status diff for the conservative CI routes. */
+import { spawnSync } from 'node:child_process';
+
+const DOCUMENTATION_PATHS = new Set(['README.md', 'CHANGELOG.md', 'ERRORS.md', 'DECISIONS.md']);
+const SKILL_PREFIX = 'skills/block-runner/';
+
+/**
+ * Classify parsed `git diff --name-status --find-renames` entries without reading git.
+ * Every path from a rename or deletion is considered, so removed or moved runtime files
+ * cannot accidentally select the smaller routes.
+ */
+export function classifyChanges(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return { route: 'full', docs: [], reason: 'empty-diff' };
+  }
+
+  const paths = entries.flatMap((entry) => entry.paths ?? []);
+  if (paths.length === 0 || paths.some((path) => typeof path !== 'string' || path.length === 0)) {
+    return { route: 'full', docs: [], reason: 'unclassified-path' };
+  }
+
+  const docs = [...new Set(paths.filter((path) => DOCUMENTATION_PATHS.has(path)
+    || (path.startsWith(SKILL_PREFIX) && path.endsWith('.md'))))].sort();
+  if (paths.every((path) => DOCUMENTATION_PATHS.has(path))) {
+    return { route: 'docs', docs, reason: 'root-documentation-only' };
+  }
+
+  if (paths.every((path) => DOCUMENTATION_PATHS.has(path) || path.startsWith(SKILL_PREFIX))
+    && paths.some((path) => path.startsWith(SKILL_PREFIX))) {
+    return { route: 'skill', docs, reason: 'skill-and-root-documentation-only' };
+  }
+
+  return { route: 'full', docs: [], reason: 'runtime-or-unclassified-path' };
+}
+
+/** Classify a diff command result while making unavailable input visibly conservative. */
+export function classifyDiffResult(result) {
+  if (!result?.ok) {
+    return { route: 'full', docs: [], reason: 'diff-unavailable', classifierFailed: true };
+  }
+
+  try {
+    return { ...classifyChanges(parseNameStatus(result.output)), classifierFailed: false };
+  } catch (error) {
+    return {
+      route: 'full',
+      docs: [],
+      reason: 'diff-parse-failed',
+      classifierFailed: true,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function parseNameStatus(output) {
+  if (typeof output !== 'string') throw new TypeError('Diff output must be a string.');
+  if (output === '') return [];
+
+  return output.trimEnd().split('\n').map((line) => {
+    const fields = line.split('\t');
+    const status = fields.shift();
+    if (!status || !/^[ACDMRTUXB]/.test(status)) {
+      throw new Error(`Unrecognised name-status entry: ${line}`);
+    }
+    const expectedPaths = status.startsWith('R') || status.startsWith('C') ? 2 : 1;
+    if (fields.length !== expectedPaths || fields.some((path) => path.length === 0)) {
+      throw new Error(`Malformed name-status entry: ${line}`);
+    }
+    return { status, paths: fields };
+  });
+}
+
+function readArguments(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if ((flag !== '--base' && flag !== '--head') || !value || values.has(flag)) {
+      throw new Error('Usage: node scripts/ci-scope.mjs --base <sha> --head <sha>');
+    }
+    values.set(flag, value);
+  }
+  if (values.size !== 2) throw new Error('Usage: node scripts/ci-scope.mjs --base <sha> --head <sha>');
+  return { base: values.get('--base'), head: values.get('--head') };
+}
+
+function main() {
+  const { base, head } = readArguments(process.argv.slice(2));
+  const diff = spawnSync('git', ['diff', '--name-status', '--find-renames', base, head], { encoding: 'utf8' });
+  if (diff.error || diff.status !== 0) {
+    const detail = diff.error?.message ?? diff.stderr.trim() ?? `exit ${diff.status}`;
+    throw new Error(`Unable to classify ${base}..${head}: ${detail}`);
+  }
+  const result = classifyDiffResult({ ok: true, output: diff.stdout });
+  if (result.classifierFailed) throw new Error(`Unable to classify ${base}..${head}: ${result.error}`);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- classify pull-request changes conservatively as documentation, skill, or full
- retain a single aggregate CI result and PR-only supersession cancellation
- cover changed-path classification and document the selected routes

## Verification

- `node --test dev/test/ci-scope.test.mjs`
- documentation, skill, private-reference, link, diff, and YAML checks

Closes #94