### PR TITLE
ci: fetch diff base for scoped contract checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The local-link gate diffs the pull-request base and head. A rebased
+          # head does not retain that base in checkout's default shallow clone.
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22.13.0
@@ -80,6 +84,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The local-link gate diffs the pull-request base and head. A rebased
+          # head does not retain that base in checkout's default shallow clone.
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22.13.0


### PR DESCRIPTION
## Summary

Ensure the documentation and skill contract jobs can diff a rebased pull request base SHA. Both jobs now fetch history before their existing whitespace/link gate.

## Checks

- `npx --no-install vitest run dev/test/ci-scope.test.mjs dev/test/node-support.test.ts`
- `git diff --check`

This fixes the verified #99 CI failure after GitHub rebased the branch onto #101.